### PR TITLE
feat(github-utils): default unresolved PR comment output to full text, with opt-in truncation and clipboard copy

### DIFF
--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -51,6 +51,14 @@ Prompt for owner/repo and let the user select an open PR when PullRequestUrl is 
 
 .PARAMETER WaitOnRateLimit
 If set, wait until rate-limit reset when 429/403 rate-limit is encountered.
+
+.PARAMETER Truncate
+If set, truncate thread comments for compact terminal readability using legacy limits
+(500 for top-level comments, 300 for latest replies). By default comments are not truncated.
+
+.PARAMETER Copy
+If set, copy the rendered output to clipboard in addition to writing to stdout.
+Clipboard copy failures are non-fatal and emit a warning.
 #>
 [CmdletBinding()]
 param(
@@ -84,6 +92,12 @@ param(
 
     [Parameter(Mandatory = $false)]
     [switch]$WaitOnRateLimit,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Truncate,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Copy,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 100)]
@@ -775,7 +789,10 @@ function Normalize-CommentText {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(10, 20000)]
-        [int]$MaxLength = 500
+        [int]$MaxLength = 500,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$DisableTruncation
     )
 
     if ([string]::IsNullOrWhiteSpace($Text)) {
@@ -783,11 +800,90 @@ function Normalize-CommentText {
     }
 
     $singleLine = (($Text -replace "\r\n", " ") -replace "\n", " " -replace "\r", " ").Trim()
+    if ($DisableTruncation.IsPresent) {
+        return $singleLine
+    }
+
     if ($singleLine.Length -le $MaxLength) {
         return $singleLine
     }
 
     return ($singleLine.Substring(0, $MaxLength) + " [...]")
+}
+
+function Get-ClipboardCommand {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param()
+
+    if ($null -ne (Get-Command Set-Clipboard -ErrorAction SilentlyContinue)) {
+        return "Set-Clipboard"
+    }
+
+    $fallbackCommands = @("pbcopy", "xclip", "xsel", "wl-copy")
+    foreach ($commandName in $fallbackCommands) {
+        if ($null -ne (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+            return $commandName
+        }
+    }
+
+    return $null
+}
+
+function Copy-ToClipboard {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [string]$Text,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$SensitiveTokens = @()
+    )
+
+    $clipboardCommand = Get-ClipboardCommand
+    if ([string]::IsNullOrWhiteSpace($clipboardCommand)) {
+        Write-Warning "W_CLIPBOARD_UNAVAILABLE: No clipboard command is available (tried Set-Clipboard, pbcopy, xclip, xsel, wl-copy)."
+        return $false
+    }
+
+    $valueToCopy = if ($null -eq $Text) { "" } else { $Text }
+
+    try {
+        switch ($clipboardCommand) {
+            "Set-Clipboard" {
+                Set-Clipboard -Value $valueToCopy
+                break
+            }
+            "pbcopy" {
+                $valueToCopy | & pbcopy
+                break
+            }
+            "xclip" {
+                $valueToCopy | & xclip -selection clipboard
+                break
+            }
+            "xsel" {
+                $valueToCopy | & xsel --clipboard --input
+                break
+            }
+            "wl-copy" {
+                $valueToCopy | & wl-copy
+                break
+            }
+            default {
+                Write-Warning "W_CLIPBOARD_UNAVAILABLE: Clipboard command '$clipboardCommand' is not supported by this script."
+                return $false
+            }
+        }
+
+        return $true
+    } catch {
+        $safeMessage = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $SensitiveTokens
+        Write-Warning "W_CLIPBOARD_COPY_FAILED: Failed to copy output using '$clipboardCommand'. $safeMessage"
+        return $false
+    }
 }
 
 function Test-CanPromptForLogin {
@@ -1311,7 +1407,10 @@ function Convert-ReviewThreadToOutputRecord {
         [int]$PrNumber,
 
         [Parameter(Mandatory = $true)]
-        [string]$GitHubHost
+        [string]$GitHubHost,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Truncate
     )
 
     if ($Thread.isResolved) {
@@ -1349,13 +1448,26 @@ function Convert-ReviewThreadToOutputRecord {
     $lineEnd = if ($null -ne $Thread.line) { [int]$Thread.line } elseif ($null -ne $lineStart) { [int]$lineStart } else { $null }
 
     $safePath = if ([string]::IsNullOrWhiteSpace($Thread.path)) { "<conversation>" } else { ($Thread.path -replace "\\", "/") }
+    $topLevelComment = if ($Truncate.IsPresent) {
+        Normalize-CommentText -Text $top.body -MaxLength 500
+    } else {
+        Normalize-CommentText -Text $top.body -DisableTruncation
+    }
+
+    $latestReplySummary = if ($null -eq $latestReply) {
+        $null
+    } elseif ($Truncate.IsPresent) {
+        Normalize-CommentText -Text $latestReply.body -MaxLength 300
+    } else {
+        Normalize-CommentText -Text $latestReply.body -DisableTruncation
+    }
 
     return [pscustomobject]@{
         path               = $safePath
         lineStart          = $lineStart
         lineEnd            = $lineEnd
-        topLevelComment    = Normalize-CommentText -Text $top.body -MaxLength 500
-        latestReplySummary = if ($null -ne $latestReply) { Normalize-CommentText -Text $latestReply.body -MaxLength 300 } else { $null }
+        topLevelComment    = $topLevelComment
+        latestReplySummary = $latestReplySummary
         threadId           = [string]$Thread.id
         prNumber           = $PrNumber
         owner              = $Owner
@@ -1441,6 +1553,9 @@ function Get-UnresolvedReviewThreads {
 
         [Parameter(Mandatory = $false)]
         [switch]$WaitOnRateLimit,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Truncate,
 
         [Parameter(Mandatory = $false)]
         [string[]]$AllowedGitHubHostsNormalized = @(),
@@ -1575,7 +1690,7 @@ query GetReviewThreads(
             }
 
             $seenThreadIds.Add([string]$thread.id) | Out-Null
-            $record = Convert-ReviewThreadToOutputRecord -Thread $thread -Owner $Owner -Repo $Repo -PrNumber $PrNumber -GitHubHost $GitHubHost
+            $record = Convert-ReviewThreadToOutputRecord -Thread $thread -Owner $Owner -Repo $Repo -PrNumber $PrNumber -GitHubHost $GitHubHost -Truncate:$Truncate
             if ($null -ne $record) {
                 $allRecords.Add($record)
             }
@@ -1778,7 +1893,7 @@ function Invoke-Main {
             Validate-GitHubTokenForRepoAccess -Owner $target.Owner -Repo $target.Repo -GitHubHost $target.Host -Headers $headers -OverallDeadlineUtc $overallDeadlineUtc -RequestTimeoutSeconds $RequestTimeoutSeconds -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
         }
 
-        $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
+        $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
     } catch {
         $message = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $sensitiveTokens
 
@@ -1809,7 +1924,7 @@ function Invoke-Main {
                 Assert-IsHashtableLike -Value $headers -Name "Headers"
 
                 Validate-GitHubTokenForRepoAccess -Owner $target.Owner -Repo $target.Repo -GitHubHost $target.Host -Headers $headers -OverallDeadlineUtc $overallDeadlineUtc -RequestTimeoutSeconds $RequestTimeoutSeconds -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
-                $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
+                $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
             } else {
                 throw $message
             }
@@ -1818,11 +1933,18 @@ function Invoke-Main {
         }
     }
 
+    $output = $null
     if ($OutputFormat -eq "json") {
-        Write-Output (Format-UnresolvedThreadsAsJson -Records $records)
+        $output = Format-UnresolvedThreadsAsJson -Records $records
     } else {
-        Write-Output (Format-UnresolvedThreadsAsText -Records $records)
+        $output = Format-UnresolvedThreadsAsText -Records $records
     }
+
+    if ($Copy.IsPresent) {
+        [void](Copy-ToClipboard -Text $output -SensitiveTokens $sensitiveTokens)
+    }
+
+    Write-Output $output
 }
 
 # Allow tests to dot-source without executing main flow.

--- a/Scripts/Utils/GitHub/README.md
+++ b/Scripts/Utils/GitHub/README.md
@@ -38,6 +38,18 @@ JSON output:
 pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -OutputFormat json
 ```
 
+Legacy compact text mode (opt-in truncation):
+
+```powershell
+pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -Truncate
+```
+
+Copy output to clipboard and still print it to stdout:
+
+```powershell
+pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -Copy
+```
+
 ## Output Contract (Text)
 
 ```text
@@ -47,6 +59,30 @@ Comment message
 Latest reply summary: <text or (none)>
 ---
 ```
+
+## Output Behavior
+
+- Default behavior is full (untruncated) comment and latest reply text.
+- `-Truncate` restores legacy compact output limits:
+	- top-level comments: 500 characters
+	- latest replies: 300 characters
+- `-Copy` copies the exact rendered output (`text` or `json`) to clipboard and still writes the same output to stdout.
+- Clipboard copy failures are non-fatal and emit a warning so normal output remains available.
+
+Clipboard command fallback order:
+
+1. `Set-Clipboard`
+2. `pbcopy`
+3. `xclip`
+4. `xsel`
+5. `wl-copy`
+
+If no supported clipboard command exists, the script warns and continues.
+
+## Migration Note
+
+Default text output now preserves full comment text. If an existing workflow expects compact bounded output,
+add `-Truncate` to restore legacy clipping behavior.
 
 ## Authentication Order
 

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -382,6 +382,70 @@ Describe "Redact-SensitiveText" {
     }
 }
 
+Describe "Get-ClipboardCommand" {
+    It "prefers Set-Clipboard when available" {
+        Mock Get-Command {
+            [pscustomobject]@{ Name = "Set-Clipboard" }
+        } -ParameterFilter { $Name -eq "Set-Clipboard" }
+
+        $result = Get-ClipboardCommand
+        $result | Should -Be "Set-Clipboard"
+    }
+
+    It "falls back to xclip when Set-Clipboard and pbcopy are unavailable" {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq "Set-Clipboard" }
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq "pbcopy" }
+        Mock Get-Command { [pscustomobject]@{ Name = "xclip" } } -ParameterFilter { $Name -eq "xclip" }
+
+        $result = Get-ClipboardCommand
+        $result | Should -Be "xclip"
+    }
+}
+
+Describe "Copy-ToClipboard" {
+    It "copies text using Set-Clipboard when available" {
+        Mock Get-ClipboardCommand { "Set-Clipboard" }
+        Mock Set-Clipboard { }
+
+        $copied = Copy-ToClipboard -Text "copy me"
+
+        $copied | Should -BeTrue
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $Value -eq "copy me" }
+    }
+
+    It "returns false and warns when clipboard command is unavailable" {
+        $script:lastWarningMessage = $null
+        Mock Get-ClipboardCommand { $null }
+        Mock Write-Warning {
+            param($Message)
+            $script:lastWarningMessage = $Message
+        }
+
+        $copied = Copy-ToClipboard -Text "copy me"
+
+        $copied | Should -BeFalse
+        $script:lastWarningMessage | Should -Match "W_CLIPBOARD_UNAVAILABLE"
+    }
+
+    It "redacts sensitive tokens when clipboard copy fails" {
+        $secret = "ghp_" + ("a" * 36)
+        $script:lastWarningMessage = $null
+        Mock Get-ClipboardCommand { "Set-Clipboard" }
+        Mock Set-Clipboard { throw "copy failure token=$secret" }
+        Mock Write-Warning {
+            param($Message)
+            $script:lastWarningMessage = $Message
+        }
+
+        $copied = Copy-ToClipboard -Text "copy me" -SensitiveTokens @($secret)
+
+        $copied | Should -BeFalse
+        $script:lastWarningMessage | Should -Match "W_CLIPBOARD_COPY_FAILED"
+        $script:lastWarningMessage | Should -Match "\*\*\*REDACTED\*\*\*"
+        $script:lastWarningMessage | Should -Not -Match [regex]::Escape($secret)
+    }
+}
+
 Describe "Convert-ReviewThreadToOutputRecord" {
     It "returns null for resolved threads" {
         $thread = [pscustomobject]@{
@@ -438,6 +502,54 @@ Describe "Convert-ReviewThreadToOutputRecord" {
         {
             [void](Convert-ReviewThreadToOutputRecord -Thread $thread -Owner "org" -Repo "repo" -PrNumber 7 -GitHubHost "github.com")
         } | Should -Throw "*E_MALFORMED_RESPONSE*comments.nodes must be an array*"
+    }
+
+    It "keeps long comments untruncated by default" {
+        $topBody = "x" * 600
+        $replyBody = "y" * 400
+        $thread = [pscustomobject]@{
+            id = "THREAD_LONG"
+            isResolved = $false
+            path = "src/long.ts"
+            startLine = 5
+            line = 9
+            comments = [pscustomobject]@{
+                nodes = @(
+                    [pscustomobject]@{ body = $topBody },
+                    [pscustomobject]@{ body = $replyBody }
+                )
+            }
+        }
+
+        $record = Convert-ReviewThreadToOutputRecord -Thread $thread -Owner "org" -Repo "repo" -PrNumber 77 -GitHubHost "github.com"
+        $record.topLevelComment.Length | Should -Be 600
+        $record.latestReplySummary.Length | Should -Be 400
+        $record.topLevelComment | Should -Not -Match "\[\.\.\.\]"
+        $record.latestReplySummary | Should -Not -Match "\[\.\.\.\]"
+    }
+
+    It "applies legacy truncation limits when Truncate is set" {
+        $topBody = "x" * 600
+        $replyBody = "y" * 400
+        $thread = [pscustomobject]@{
+            id = "THREAD_TRUNCATE"
+            isResolved = $false
+            path = "src/long.ts"
+            startLine = 5
+            line = 9
+            comments = [pscustomobject]@{
+                nodes = @(
+                    [pscustomobject]@{ body = $topBody },
+                    [pscustomobject]@{ body = $replyBody }
+                )
+            }
+        }
+
+        $record = Convert-ReviewThreadToOutputRecord -Thread $thread -Owner "org" -Repo "repo" -PrNumber 77 -GitHubHost "github.com" -Truncate
+        $record.topLevelComment.Length | Should -Be 506
+        $record.latestReplySummary.Length | Should -Be 306
+        $record.topLevelComment | Should -Match "\[\.\.\.\]$"
+        $record.latestReplySummary | Should -Match "\[\.\.\.\]$"
     }
 }
 
@@ -1174,6 +1286,60 @@ Describe "Get-UnresolvedReviewThreads" {
             [void](Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)))
         } | Should -Throw "*E_MALFORMED_RESPONSE*endCursor must be a string or null*"
     }
+
+    It "returns full comment bodies by default" {
+        $topBody = "x" * 600
+        $replyBody = "y" * 400
+
+        Mock Invoke-GitHubRequestWithRetry {
+            return @{
+                data = @{
+                    repository = @{
+                        pullRequest = @{
+                            reviewThreads = @{
+                                pageInfo = @{ hasNextPage = $false; endCursor = $null }
+                                nodes = @(
+                                    @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @(@{ body = $topBody }, @{ body = $replyBody }) } }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $records = Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30))
+        $records.Count | Should -Be 1
+        $records[0].topLevelComment.Length | Should -Be 600
+        $records[0].latestReplySummary.Length | Should -Be 400
+    }
+
+    It "applies truncation when Truncate is set" {
+        $topBody = "x" * 600
+        $replyBody = "y" * 400
+
+        Mock Invoke-GitHubRequestWithRetry {
+            return @{
+                data = @{
+                    repository = @{
+                        pullRequest = @{
+                            reviewThreads = @{
+                                pageInfo = @{ hasNextPage = $false; endCursor = $null }
+                                nodes = @(
+                                    @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @(@{ body = $topBody }, @{ body = $replyBody }) } }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $records = Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)) -Truncate
+        $records.Count | Should -Be 1
+        $records[0].topLevelComment | Should -Match "\[\.\.\.\]$"
+        $records[0].latestReplySummary | Should -Match "\[\.\.\.\]$"
+    }
 }
 
 Describe "Resolve-PullRequestTarget" {
@@ -1566,6 +1732,166 @@ Describe "Invoke-Main" {
 
         { Invoke-Main } | Should -Throw "*E_AUTH_REQUIRED*"
         Assert-MockCalled Read-Host -Times 0 -Scope It
+    }
+
+    It "copies output when Copy is set and still writes to stdout" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($false)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($true)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads {
+            @(
+                [pscustomobject]@{
+                    path = "src/a.ts"
+                    lineStart = 1
+                    lineEnd = 1
+                    topLevelComment = "x"
+                    latestReplySummary = $null
+                }
+            )
+        }
+        Mock Format-UnresolvedThreadsAsText { "copied output" }
+        Mock Copy-ToClipboard { $true }
+        $script:lastOutput = $null
+        Mock Write-Output {
+            param($InputObject)
+            $script:lastOutput = $InputObject
+        }
+
+        Invoke-Main
+
+        $script:lastOutput | Should -Be "copied output"
+        Assert-MockCalled Copy-ToClipboard -Times 1 -Scope It -ParameterFilter { $Text -eq "copied output" }
+    }
+
+    It "writes stdout output even when copy fails" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($false)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($true)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads {
+            @(
+                [pscustomobject]@{
+                    path = "src/a.ts"
+                    lineStart = 1
+                    lineEnd = 1
+                    topLevelComment = "x"
+                    latestReplySummary = $null
+                }
+            )
+        }
+        Mock Format-UnresolvedThreadsAsText { "still output" }
+        Mock Copy-ToClipboard { $false }
+        $script:lastOutput = $null
+        Mock Write-Output {
+            param($InputObject)
+            $script:lastOutput = $InputObject
+        }
+
+        Invoke-Main
+
+        $script:lastOutput | Should -Be "still output"
+        Assert-MockCalled Copy-ToClipboard -Times 1 -Scope It
+        Assert-MockCalled Write-Output -Times 1 -Scope It -ParameterFilter { $InputObject -eq "still output" }
+    }
+
+    It "threads Truncate through unresolved thread retrieval" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($true)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($false)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads {
+            @(
+                [pscustomobject]@{
+                    path = "src/a.ts"
+                    lineStart = 1
+                    lineEnd = 1
+                    topLevelComment = "x"
+                    latestReplySummary = $null
+                }
+            )
+        }
+        Mock Format-UnresolvedThreadsAsText { "ok" }
+        Mock Write-Output { }
+
+        Invoke-Main
+
+        Assert-MockCalled Get-UnresolvedReviewThreads -Times 1 -Scope It -ParameterFilter { $Truncate.IsPresent }
     }
 }
 

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -665,3 +665,42 @@ Describe "Retry test determinism conventions" {
         )
     }
 }
+
+Describe "GitHub output and clipboard conventions" {
+    It "keeps Copy and Truncate parameters in the PR unresolved comments script" {
+        $scriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $scriptPath -Raw
+
+        $content | Should -Match '\[switch\]\$Truncate'
+        $content | Should -Match '\[switch\]\$Copy'
+        $content | Should -Match '\.PARAMETER\s+Truncate'
+        $content | Should -Match '\.PARAMETER\s+Copy'
+    }
+
+    It "keeps truncation conditional instead of unconditional in record conversion" {
+        $scriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $scriptPath -Raw
+
+        $content | Should -Match 'function\s+Convert-ReviewThreadToOutputRecord[\s\S]*\[switch\]\$Truncate'
+        $content | Should -Match 'function\s+Convert-ReviewThreadToOutputRecord[\s\S]*if\s*\(\$Truncate\.IsPresent\)'
+        $content | Should -Match 'function\s+Convert-ReviewThreadToOutputRecord[\s\S]*Normalize-CommentText\s+-Text\s+\$top\.body\s+-MaxLength\s+500'
+        $content | Should -Match 'function\s+Convert-ReviewThreadToOutputRecord[\s\S]*Normalize-CommentText\s+-Text\s+\$top\.body\s+-DisableTruncation'
+    }
+
+    It "keeps clipboard copy non-fatal and output additive" {
+        $scriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $scriptPath -Raw
+
+        $content | Should -Match 'function\s+Copy-ToClipboard[\s\S]*Write-Warning\s+"W_CLIPBOARD_UNAVAILABLE'
+        $content | Should -Match 'function\s+Copy-ToClipboard[\s\S]*Write-Warning\s+"W_CLIPBOARD_COPY_FAILED'
+        $content | Should -Match 'function\s+Invoke-Main[\s\S]*if\s*\(\$Copy\.IsPresent\)'
+        $content | Should -Match 'function\s+Invoke-Main[\s\S]*Write-Output\s+\$output'
+    }
+
+    It "keeps regression coverage for stdout on copy failure" {
+        $testsPath = Join-Path -Path $script:repoRoot -ChildPath "Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1"
+        $testsContent = Get-Content -Path $testsPath -Raw
+
+        $testsContent | Should -Match 'writes stdout output even when copy fails'
+    }
+}


### PR DESCRIPTION
## Summary
This PR improves the unresolved PR comments utility by making full, untruncated comment text the default output and adding explicit controls for compact output and clipboard workflows.

## Why
The utility had two valid but competing use cases:
1. Full context for review and triage.
2. Compact output for terminal readability and sharing.

This change makes full context the default while preserving compact behavior as an opt-in mode.

## What Changed
1. Added Truncate switch parameter.
2. Added Copy switch parameter.
3. Updated comment normalization flow to support conditional truncation.
4. Threaded Truncate through unresolved-thread retrieval and main execution path.
5. Added clipboard support with command fallback order:
   1. Set-Clipboard
   2. pbcopy
   3. xclip
   4. xsel
   5. wl-copy
6. Ensured clipboard copy is additive:
   1. Output is still written to stdout.
   2. Clipboard failures are non-fatal warnings.
   3. Sensitive tokens are redacted in warning messages.
7. Updated documentation with new usage examples and migration guidance.
8. Expanded tests to lock in behavior and prevent regressions:
   1. Clipboard command resolution and copy behavior
   2. Default full-text behavior
   3. Truncate legacy limits
   4. Stdout behavior when copy fails
   5. Script safety conventions for parameter and behavior contracts

## Backward Compatibility / Migration
1. Default behavior now returns full comment and latest reply text.
2. Existing workflows that depend on compact output should pass Truncate to restore legacy clipping limits.

## Validation
1. Ran:
   pwsh -NoProfile -Command "Invoke-Pester -Path 'Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1' -Output Detailed"
2. Result: Passed

## Risk
Low to medium:
1. Intentional default-output behavior change, documented in README.
2. Regression risk mitigated by targeted tests and convention checks.
