### PR TITLE
Better Copy: Clipboard Fallback, Strict Mode, and File Output

### DIFF
--- a/.llm/skill-details/github-pr-unresolved-comments.md
+++ b/.llm/skill-details/github-pr-unresolved-comments.md
@@ -16,12 +16,43 @@ Keep HTTP calls inside approved wrappers and preserve retry behavior for transie
 
 Keep diagnostics explicit and maintain coverage for URI safety, retries, and host restrictions.
 
+## Clipboard Fallback And Strict Mode
+
+Keep clipboard behavior deterministic and non-breaking:
+
+- `-Copy` is best-effort by default and must never suppress stdout output.
+- Copy attempts use ordered fallback strategies, including OSC52-capable PowerShell path when available.
+- `-CopyStrict` is opt-in and must fail fast if used without `-Copy`.
+- When `-CopyStrict` is present and copy fails, throw `E_CLIPBOARD_COPY_FAILED`.
+- Warning/error text must continue redacting sensitive tokens.
+
+## Output File Contract
+
+When `-OutputPath` is supplied:
+
+- Resolve to an absolute path deterministically.
+- Create missing parent directories.
+- Write UTF-8 content via `[System.IO.File]::WriteAllText(..., [System.Text.Encoding]::UTF8)`.
+- Keep stdout output unchanged for automation compatibility.
+- Use explicit `E_INVALID_OUTPUT_PATH` / `E_OUTPUT_WRITE_FAILED` diagnostics.
+
+## PowerShell Completion Contract
+
+For PowerShell terminal usage, keep value discovery aids in the script parameter block:
+
+- `-OutputFormat` keeps completions for `text` and `json`.
+- `-GitHubHost` keeps completion hint for `github.com`.
+- Completion metadata is additive and must not weaken validation constraints.
+
 ## Workflow
 
 1. Validate host and owner/repo parameters early.
 2. Keep HTTP calls inside approved wrappers.
 3. Preserve retry behavior for transient status codes.
 4. Keep non-global IP blocks and host allowlist checks active.
+5. Preserve copy fallback order and strict mode behavior.
+6. Preserve output-file write semantics and UTF-8 encoding.
+7. Keep PowerShell completion metadata aligned with supported parameter values.
 
 ## References
 

--- a/.llm/skill-details/github-pr-unresolved-comments.md
+++ b/.llm/skill-details/github-pr-unresolved-comments.md
@@ -22,17 +22,18 @@ Keep clipboard behavior deterministic and non-breaking:
 
 - `-Copy` is best-effort by default and must never suppress stdout output.
 - Copy attempts use ordered fallback strategies, including OSC52-capable PowerShell path when available.
+- Native clipboard tools (pbcopy, xclip, xsel, wl-copy) must check `$LASTEXITCODE` after invocation; non-zero means the attempt failed and the next strategy should be tried.
 - `-CopyStrict` is opt-in and must fail fast if used without `-Copy`.
 - When `-CopyStrict` is present and copy fails, throw `E_CLIPBOARD_COPY_FAILED`.
 - Warning/error text must continue redacting sensitive tokens.
 
 ## Output File Contract
 
-When `-OutputPath` is supplied:
+When `-OutputPath` is supplied (capture `$PSBoundParameters` at script scope into `$script:TopLevelBoundParameters` and use `.ContainsKey("OutputPath")` to detect, not `IsNullOrWhiteSpace`):
 
 - Resolve to an absolute path deterministically.
 - Create missing parent directories.
-- Write UTF-8 content via `[System.IO.File]::WriteAllText(..., [System.Text.Encoding]::UTF8)`.
+- Write UTF-8 content without BOM via `[System.IO.File]::WriteAllText(..., [System.Text.UTF8Encoding]::new($false))`.
 - Keep stdout output unchanged for automation compatibility.
 - Use explicit `E_INVALID_OUTPUT_PATH` / `E_OUTPUT_WRITE_FAILED` diagnostics.
 

--- a/.llm/skill-details/github-pr-unresolved-comments.md
+++ b/.llm/skill-details/github-pr-unresolved-comments.md
@@ -26,6 +26,8 @@ Keep clipboard behavior deterministic and non-breaking:
 - `-CopyStrict` is opt-in and must fail fast if used without `-Copy`.
 - When `-CopyStrict` is present and copy fails, throw `E_CLIPBOARD_COPY_FAILED`.
 - Warning/error text must continue redacting sensitive tokens.
+- Unit tests must assert OSC52-first failover behavior: when `Set-Clipboard -AsOSC52` fails, fallback must continue to plain `Set-Clipboard` and still succeed when possible.
+- Safety conventions should enforce both OSC52 gating (`$supportsOsc52` + `Test-ShouldUseClipboardOsc52`) and OSC52-before-Set-Clipboard priority ordering in `Get-ClipboardCommandPriority`.
 
 ## Output File Contract
 

--- a/.llm/skills-index.md
+++ b/.llm/skills-index.md
@@ -32,6 +32,6 @@ This file is generated. Do not edit generated sections manually.
 
 | Skill Card | Expanded Guide | Trigger Keywords | Usage |
 | --- | --- | --- | --- |
-| [Github Pr Unresolved Comments](./skills/github-pr-unresolved-comments.md) | [Expanded Guide](./skill-details/github-pr-unresolved-comments.md) | github api, unresolved comments, host allowlist, retries | Preserve GitHub utility safety and retry behavior |
+| [Github Pr Unresolved Comments](./skills/github-pr-unresolved-comments.md) | [Expanded Guide](./skill-details/github-pr-unresolved-comments.md) | github api, unresolved comments, host allowlist, retries, clipboard fallback, output file, powershell completion | Preserve GitHub utility safety and UX contracts |
 
 <!-- END GENERATED SKILLS INDEX -->

--- a/.llm/skills-index.md
+++ b/.llm/skills-index.md
@@ -11,7 +11,7 @@ This file is generated. Do not edit generated sections manually.
 | --- | --- | --- | --- |
 | [Config Snapshot Safety](./skills/config-snapshot-safety.md) | [Expanded Guide](./skill-details/config-snapshot-safety.md) | config snapshots, encrypted payloads, json validation exclusions | Keep config snapshot handling and exclusions safe |
 | [Cross Language Quality Gate](./skills/cross-language-quality-gate.md) | [Expanded Guide](./skill-details/cross-language-quality-gate.md) | quality gate, pre-commit, ci parity, clean tree, full validation, session close | Apply cross-language local and CI validation flow |
-| [Powershell Strict Mode Helpers](./skills/powershell-strict-mode-helpers.md) | [Expanded Guide](./skill-details/powershell-strict-mode-helpers.md) | powershell, strict mode, lastexitcode, helper function | Implement strict-mode-safe PowerShell behavior |
+| [PowerShell Strict Mode Helpers](./skills/powershell-strict-mode-helpers.md) | [Expanded Guide](./skill-details/powershell-strict-mode-helpers.md) | powershell, strict mode, lastexitcode, helper function | Implement strict-mode-safe PowerShell behavior |
 
 ## Quality
 
@@ -25,13 +25,13 @@ This file is generated. Do not edit generated sections manually.
 | Skill Card | Expanded Guide | Trigger Keywords | Usage |
 | --- | --- | --- | --- |
 | [Devcontainer Bootstrap](./skills/devcontainer-bootstrap.md) | [Expanded Guide](./skill-details/devcontainer-bootstrap.md) | devcontainer, bootstrap, toolchain, setup parity | Use devcontainer bootstrap for consistent quality tooling |
-| [Macos Applescript Validation](./skills/macos-applescript-validation.md) | [Expanded Guide](./skill-details/macos-applescript-validation.md) | macos, applescript, osacompile, migration fallback | Keep macOS AppleScript validation migration-safe |
+| [macOS AppleScript Validation](./skills/macos-applescript-validation.md) | [Expanded Guide](./skill-details/macos-applescript-validation.md) | macos, applescript, osacompile, migration fallback | Keep macOS AppleScript validation migration-safe |
 | [Windows Language Validation](./skills/windows-language-validation.md) | [Expanded Guide](./skill-details/windows-language-validation.md) | windows, autohotkey, batch, fast lane, runtime budget | Preserve Windows PR lane validation contracts |
 
 ## GitHub
 
 | Skill Card | Expanded Guide | Trigger Keywords | Usage |
 | --- | --- | --- | --- |
-| [Github Pr Unresolved Comments](./skills/github-pr-unresolved-comments.md) | [Expanded Guide](./skill-details/github-pr-unresolved-comments.md) | github api, unresolved comments, host allowlist, retries, clipboard fallback, output file, powershell completion | Preserve GitHub utility safety and UX contracts |
+| [GitHub PR Unresolved Comments](./skills/github-pr-unresolved-comments.md) | [Expanded Guide](./skill-details/github-pr-unresolved-comments.md) | github api, unresolved comments, host allowlist, retries, clipboard fallback, output file, powershell completion | Preserve GitHub utility safety and UX contracts |
 
 <!-- END GENERATED SKILLS INDEX -->

--- a/.llm/skills/github-pr-unresolved-comments.md
+++ b/.llm/skills/github-pr-unresolved-comments.md
@@ -1,4 +1,4 @@
-<!-- trigger: github api, unresolved comments, host allowlist, retries | Preserve GitHub utility safety and retry behavior | GitHub | skill-details/github-pr-unresolved-comments.md -->
+<!-- trigger: github api, unresolved comments, host allowlist, retries, clipboard fallback, output file, powershell completion | Preserve GitHub utility safety and UX contracts | GitHub | skill-details/github-pr-unresolved-comments.md -->
 
 # GitHub PR Unresolved Comments
 
@@ -11,4 +11,7 @@ Lightweight skill card for GitHub API safety and retry behavior.
 - [Host allowlist and input validation](../skill-details/github-pr-unresolved-comments.md#host-allowlist-and-input-validation)
 - [Retry-safe GitHub request flow](../skill-details/github-pr-unresolved-comments.md#retry-safe-github-request-flow)
 - [Actionable diagnostics and resilience tests](../skill-details/github-pr-unresolved-comments.md#actionable-diagnostics-and-resilience-tests)
+- [Clipboard fallback and strict mode](../skill-details/github-pr-unresolved-comments.md#clipboard-fallback-and-strict-mode)
+- [Output file contract](../skill-details/github-pr-unresolved-comments.md#output-file-contract)
+- [PowerShell completion contract](../skill-details/github-pr-unresolved-comments.md#powershell-completion-contract)
 - Quick check: `pwsh -NoLogo -NoProfile -File Scripts/Utils/Run-PreCommitValidation.ps1`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ These utilities do not modify backup/restore behavior.
 Current utility:
 
 - `Get-UnresolvedPRComments.ps1`: read unresolved PR review threads from GitHub and render plain-text or JSON output.
+  - Supports clipboard export with `-Copy` and strict failure mode via `-CopyStrict`.
+  - Supports writing output to UTF-8 files with `-OutputPath` while still emitting stdout.
 
 ## Script Quality Platform
 

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -1642,6 +1642,7 @@ function Format-UnresolvedThreadsAsText {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [object[]]$Records
     )
 
@@ -1674,6 +1675,7 @@ function Format-UnresolvedThreadsAsJson {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [object[]]$Records
     )
 
@@ -2029,6 +2031,7 @@ function Invoke-Main {
     }
 
     $initialSensitive = @()
+    $records = @()
     $isGitHubHostExplicitlyProvided = $script:TopLevelBoundParameters.ContainsKey("GitHubHost")
     $allowedGitHubHostsNormalized = Get-NormalizedGitHubHostAllowlist -AllowedGitHubHosts $AllowedGitHubHosts
 
@@ -2063,7 +2066,7 @@ function Invoke-Main {
             Validate-GitHubTokenForRepoAccess -Owner $target.Owner -Repo $target.Repo -GitHubHost $target.Host -Headers $headers -OverallDeadlineUtc $overallDeadlineUtc -RequestTimeoutSeconds $RequestTimeoutSeconds -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
         }
 
-        $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
+        $records = @(Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens)
     }
     catch {
         $message = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $sensitiveTokens
@@ -2095,7 +2098,7 @@ function Invoke-Main {
                 Assert-IsHashtableLike -Value $headers -Name "Headers"
 
                 Validate-GitHubTokenForRepoAccess -Owner $target.Owner -Repo $target.Repo -GitHubHost $target.Host -Headers $headers -OverallDeadlineUtc $overallDeadlineUtc -RequestTimeoutSeconds $RequestTimeoutSeconds -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
-                $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
+                $records = @(Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens)
             }
             else {
                 throw $message
@@ -2134,7 +2137,12 @@ if (-not $NoRun.IsPresent -and $MyInvocation.InvocationName -ne ".") {
         Invoke-Main
     }
     catch {
-        Write-Error $_
+        if ($null -ne $_) {
+            Microsoft.PowerShell.Utility\Write-Error -ErrorRecord $_
+        }
+        else {
+            Microsoft.PowerShell.Utility\Write-Error "E_UNEXPECTED: Script failed with an unknown error."
+        }
         exit 1
     }
 }

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -46,6 +46,10 @@ Explicit GitHub token. This has highest priority if provided.
 .PARAMETER OutputFormat
 text (default) or json.
 
+.PARAMETER OutputPath
+Optional file path to also write the rendered output. The script writes UTF-8 text,
+creates parent directories when needed, and still writes output to stdout.
+
 .PARAMETER Interactive
 Prompt for owner/repo and let the user select an open PR when PullRequestUrl is not provided.
 
@@ -59,6 +63,10 @@ If set, truncate thread comments for compact terminal readability using legacy l
 .PARAMETER Copy
 If set, copy the rendered output to clipboard in addition to writing to stdout.
 Clipboard copy failures are non-fatal and emit a warning.
+
+.PARAMETER CopyStrict
+Only valid together with -Copy. If set, clipboard copy failure becomes a terminating
+error after output is rendered.
 #>
 [CmdletBinding()]
 param(
@@ -72,6 +80,7 @@ param(
     [string]$Repo,
 
     [Parameter(Mandatory = $false)]
+    [ArgumentCompletions("github.com")]
     [string]$GitHubHost = "github.com",
 
     [Parameter(Mandatory = $false)]
@@ -84,8 +93,13 @@ param(
     [string]$Token,
 
     [Parameter(Mandatory = $false)]
+    [ArgumentCompletions("text", "json")]
     [ValidateSet("text", "json")]
     [string]$OutputFormat = "text",
+
+    [Parameter(Mandatory = $false)]
+    [Alias("OutFile")]
+    [string]$OutputPath,
 
     [Parameter(Mandatory = $false)]
     [switch]$Interactive,
@@ -98,6 +112,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [switch]$Copy,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$CopyStrict,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 100)]
@@ -250,7 +267,8 @@ function Get-HeaderValues {
                 if ($Headers.TryGetValues($candidate, [ref]$values)) {
                     return @(Convert-ToStringArray -Value $values)
                 }
-            } catch {
+            }
+            catch {
                 # Continue to alternative lookup paths.
             }
         }
@@ -309,14 +327,16 @@ function Get-HeaderValueDiagnostics {
     $preview = @($Values | Select-Object -First 3 | ForEach-Object {
             if ($_.Length -gt 80) {
                 $_.Substring(0, 80) + "..."
-            } else {
+            }
+            else {
                 $_
             }
         })
 
     $previewText = if ($preview.Count -gt 0) {
         "'" + ($preview -join "', '") + "'"
-    } else {
+    }
+    else {
         "(none)"
     }
 
@@ -489,7 +509,7 @@ function Assert-GitHubOwnerRepoFormat {
 
     return [pscustomobject]@{
         Owner = $normalizedOwner
-        Repo = $normalizedRepo
+        Repo  = $normalizedRepo
     }
 }
 
@@ -516,9 +536,9 @@ function Parse-GitHubPullRequestUrl {
     $validatedOwnerRepo = Assert-GitHubOwnerRepoFormat -Owner $match.Groups["owner"].Value -Repo $match.Groups["repo"].Value -Context "PullRequestUrl"
 
     return [pscustomobject]@{
-        Host            = $hostValue
-        Owner           = $validatedOwnerRepo.Owner
-        Repo            = $validatedOwnerRepo.Repo
+        Host              = $hostValue
+        Owner             = $validatedOwnerRepo.Owner
+        Repo              = $validatedOwnerRepo.Repo
         PullRequestNumber = [int]$match.Groups["pr"].Value
     }
 }
@@ -649,9 +669,11 @@ function Get-NormalizedGitHubHostAllowlist {
     if ($rawHosts.Count -eq 0) {
         $envAllowlist = if (-not [string]::IsNullOrWhiteSpace($env:WALLSTOP_GITHUB_ALLOWED_HOSTS)) {
             $env:WALLSTOP_GITHUB_ALLOWED_HOSTS
-        } elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ALLOWED_HOSTS)) {
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ALLOWED_HOSTS)) {
             $env:GITHUB_ALLOWED_HOSTS
-        } else {
+        }
+        else {
             $null
         }
 
@@ -674,7 +696,8 @@ function Get-NormalizedGitHubHostAllowlist {
     foreach ($rawHost in $rawHosts) {
         try {
             $normalizedHost = Assert-GitHubHostFormat -GitHubHost $rawHost -Context "AllowedGitHubHosts"
-        } catch {
+        }
+        catch {
             $safeMessage = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens @()
             throw "E_CONFIG_ERROR: Invalid host allowlist entry '$rawHost'. $safeMessage"
         }
@@ -769,7 +792,7 @@ function Get-GitHubHeaders {
     )
 
     [hashtable]$headers = @{
-        "Accept" = "application/vnd.github+json"
+        "Accept"     = "application/vnd.github+json"
         "User-Agent" = "wallstop-utils-unresolved-pr-comments"
     }
 
@@ -816,18 +839,65 @@ function Get-ClipboardCommand {
     [CmdletBinding()]
     param()
 
-    if ($null -ne (Get-Command Set-Clipboard -ErrorAction SilentlyContinue)) {
-        return "Set-Clipboard"
+    $commands = @(Get-ClipboardCommandPriority)
+    if ((Get-SafeCount -InputObject $commands) -eq 0) {
+        return $null
+    }
+
+    return $commands[0]
+}
+
+function Test-ShouldUseClipboardOsc52 {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param()
+
+    return ($env:TERM_PROGRAM -eq "vscode") -or
+    (-not [string]::IsNullOrWhiteSpace($env:WT_SESSION)) -or
+    (-not [string]::IsNullOrWhiteSpace($env:SSH_CLIENT)) -or
+    (-not [string]::IsNullOrWhiteSpace($env:SSH_TTY))
+}
+
+function Get-ClipboardCommandPriority {
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param()
+
+    $commands = New-Object System.Collections.Generic.List[string]
+    $setClipboardCommand = Get-Command Set-Clipboard -ErrorAction SilentlyContinue
+    if ($null -ne $setClipboardCommand) {
+        $supportsOsc52 = $false
+        if ($setClipboardCommand.PSObject.Properties.Name -contains "Parameters" -and $null -ne $setClipboardCommand.Parameters) {
+            $supportsOsc52 = ($setClipboardCommand.Parameters.Keys -contains "AsOSC52")
+        }
+
+        if ($supportsOsc52 -and (Test-ShouldUseClipboardOsc52)) {
+            $commands.Add("Set-Clipboard-AsOSC52") | Out-Null
+        }
+
+        $commands.Add("Set-Clipboard") | Out-Null
     }
 
     $fallbackCommands = @("pbcopy", "xclip", "xsel", "wl-copy")
     foreach ($commandName in $fallbackCommands) {
         if ($null -ne (Get-Command $commandName -ErrorAction SilentlyContinue)) {
-            return $commandName
+            $commands.Add($commandName) | Out-Null
         }
     }
 
-    return $null
+    if ($commands.Count -eq 0) {
+        return @() # array-unwrap-safe: callers always wrap with @()
+    }
+
+    $deduplicated = New-Object System.Collections.Generic.List[string]
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($command in $commands) {
+        if ($seen.Add($command)) {
+            $deduplicated.Add($command) | Out-Null
+        }
+    }
+
+    return $deduplicated.ToArray()
 }
 
 function Copy-ToClipboard {
@@ -842,47 +912,129 @@ function Copy-ToClipboard {
         [string[]]$SensitiveTokens = @()
     )
 
-    $clipboardCommand = Get-ClipboardCommand
-    if ([string]::IsNullOrWhiteSpace($clipboardCommand)) {
+    $clipboardCommands = @(Get-ClipboardCommandPriority)
+    if ((Get-SafeCount -InputObject $clipboardCommands) -eq 0) {
         Write-Warning "W_CLIPBOARD_UNAVAILABLE: No clipboard command is available (tried Set-Clipboard, pbcopy, xclip, xsel, wl-copy)."
         return $false
     }
 
     $valueToCopy = if ($null -eq $Text) { "" } else { $Text }
+    $attemptErrors = New-Object System.Collections.Generic.List[string]
 
-    try {
-        switch ($clipboardCommand) {
-            "Set-Clipboard" {
-                Set-Clipboard -Value $valueToCopy
-                break
-            }
-            "pbcopy" {
-                $valueToCopy | & pbcopy
-                break
-            }
-            "xclip" {
-                $valueToCopy | & xclip -selection clipboard
-                break
-            }
-            "xsel" {
-                $valueToCopy | & xsel --clipboard --input
-                break
-            }
-            "wl-copy" {
-                $valueToCopy | & wl-copy
-                break
-            }
-            default {
-                Write-Warning "W_CLIPBOARD_UNAVAILABLE: Clipboard command '$clipboardCommand' is not supported by this script."
-                return $false
+    foreach ($clipboardCommand in $clipboardCommands) {
+        try {
+            switch ($clipboardCommand) {
+                "Set-Clipboard-AsOSC52" {
+                    Set-Clipboard -Value $valueToCopy -AsOSC52
+                    return $true
+                }
+                "Set-Clipboard" {
+                    Set-Clipboard -Value $valueToCopy
+                    return $true
+                }
+                "pbcopy" {
+                    $valueToCopy | & pbcopy
+                    return $true
+                }
+                "xclip" {
+                    $valueToCopy | & xclip -selection clipboard
+                    return $true
+                }
+                "xsel" {
+                    $valueToCopy | & xsel --clipboard --input
+                    return $true
+                }
+                "wl-copy" {
+                    $valueToCopy | & wl-copy
+                    return $true
+                }
+                default {
+                    $attemptErrors.Add("[$clipboardCommand] unsupported command") | Out-Null
+                    continue
+                }
             }
         }
+        catch {
+            $safeMessage = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $SensitiveTokens
+            $attemptErrors.Add("[$clipboardCommand] $safeMessage") | Out-Null
+            continue
+        }
+    }
 
-        return $true
-    } catch {
+    $attemptSummary = if ($attemptErrors.Count -gt 0) {
+        ($attemptErrors -join " | ")
+    }
+    else {
+        "(no attempt diagnostics captured)"
+    }
+
+    Write-Warning "W_CLIPBOARD_COPY_FAILED: Failed to copy output using available clipboard commands. Attempts: $attemptSummary"
+    return $false
+}
+
+function Resolve-OutputFilePath {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$SensitiveTokens = @()
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "E_INVALID_OUTPUT_PATH: OutputPath cannot be empty."
+    }
+
+    try {
+        $trimmedPath = $Path.Trim()
+        $resolvedPath = if ([System.IO.Path]::IsPathRooted($trimmedPath)) {
+            [System.IO.Path]::GetFullPath($trimmedPath)
+        }
+        else {
+            $combined = Join-Path -Path (Get-Location).Path -ChildPath $trimmedPath
+            [System.IO.Path]::GetFullPath($combined)
+        }
+
+        $directoryPath = [System.IO.Path]::GetDirectoryName($resolvedPath)
+        if (-not [string]::IsNullOrWhiteSpace($directoryPath) -and -not (Test-Path -Path $directoryPath -PathType Container)) {
+            [void][System.IO.Directory]::CreateDirectory($directoryPath)
+        }
+
+        return $resolvedPath
+    }
+    catch {
         $safeMessage = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $SensitiveTokens
-        Write-Warning "W_CLIPBOARD_COPY_FAILED: Failed to copy output using '$clipboardCommand'. $safeMessage"
-        return $false
+        throw "E_INVALID_OUTPUT_PATH: Failed to resolve OutputPath '$Path'. $safeMessage"
+    }
+}
+
+function Write-RenderedOutputToFile {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [string]$Text,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$SensitiveTokens = @()
+    )
+
+    $resolvedPath = Resolve-OutputFilePath -Path $OutputPath -SensitiveTokens $SensitiveTokens
+    $content = if ($null -eq $Text) { "" } else { $Text }
+
+    try {
+        [System.IO.File]::WriteAllText($resolvedPath, $content, [System.Text.Encoding]::UTF8)
+        return $resolvedPath
+    }
+    catch {
+        $safeMessage = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $SensitiveTokens
+        throw "E_OUTPUT_WRITE_FAILED: Failed to write output to '$resolvedPath'. $safeMessage"
     }
 }
 
@@ -892,7 +1044,8 @@ function Test-CanPromptForLogin {
 
     try {
         return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -936,7 +1089,8 @@ function Get-AuthToken {
         if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($tokenOutput)) {
             return $tokenOutput.Trim()
         }
-    } catch {
+    }
+    catch {
         # Continue to interactive fallback only if allowed.
     }
 
@@ -1016,7 +1170,8 @@ function Invoke-GitHubRequestWithRetry {
 
             $jsonBody = if ($null -eq $Body) { "{}" } else { $Body | ConvertTo-Json -Depth 20 }
             return Invoke-RestMethod -Method POST -Uri $Uri -Headers $Headers -ContentType "application/json" -Body $jsonBody -TimeoutSec $RequestTimeoutSeconds
-        } catch {
+        }
+        catch {
             $statusCode = Get-HttpStatusCode -Exception $_.Exception
             $responseHeaders = Get-ResponseHeaders -Exception $_.Exception
 
@@ -1029,11 +1184,13 @@ function Invoke-GitHubRequestWithRetry {
                         $retryAfterSeconds = 0
                         if ([int]::TryParse($retryAfterCandidate, [ref]$retryAfterSeconds) -and $retryAfterSeconds -gt 0) {
                             $resetValue = ([DateTimeOffset]::UtcNow.AddSeconds($retryAfterSeconds + 1).ToUnixTimeSeconds()).ToString()
-                        } else {
+                        }
+                        else {
                             $retryAfterDate = [DateTimeOffset]::MinValue
                             if ([DateTimeOffset]::TryParseExact($retryAfterCandidate, "r", [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$retryAfterDate)) {
                                 $resetValue = $retryAfterDate.ToUnixTimeSeconds().ToString()
-                            } else {
+                            }
+                            else {
                                 throw "E_RATE_LIMIT: Invalid Retry-After value '$retryAfterCandidate'. $(Get-HeaderValueDiagnostics -Key 'Retry-After' -Values @($retryAfterValue))"
                             }
                         }
@@ -1283,7 +1440,8 @@ function Validate-GitHubTokenForRepoAccess {
 
                 $headerDiagnostics = if ((Get-SafeCount -InputObject $headerKeys) -gt 0) {
                     "Headers seen: $($headerKeys -join ', ')"
-                } else {
+                }
+                else {
                     "Headers seen: (none)"
                 }
 
@@ -1374,7 +1532,8 @@ function Select-PullRequestInteractively {
         $numeric = [int]$selection
         if ($numeric -ge 1 -and $numeric -le $pullCount) {
             $selectedPr = $pulls[$numeric - 1]
-        } else {
+        }
+        else {
             $selectedPr = $pulls | Where-Object { $_.number -eq $numeric } | Select-Object -First 1
         }
     }
@@ -1450,15 +1609,18 @@ function Convert-ReviewThreadToOutputRecord {
     $safePath = if ([string]::IsNullOrWhiteSpace($Thread.path)) { "<conversation>" } else { ($Thread.path -replace "\\", "/") }
     $topLevelComment = if ($Truncate.IsPresent) {
         Normalize-CommentText -Text $top.body -MaxLength 500
-    } else {
+    }
+    else {
         Normalize-CommentText -Text $top.body -DisableTruncation
     }
 
     $latestReplySummary = if ($null -eq $latestReply) {
         $null
-    } elseif ($Truncate.IsPresent) {
+    }
+    elseif ($Truncate.IsPresent) {
         Normalize-CommentText -Text $latestReply.body -MaxLength 300
-    } else {
+    }
+    else {
         Normalize-CommentText -Text $latestReply.body -DisableTruncation
     }
 
@@ -1494,7 +1656,8 @@ function Format-UnresolvedThreadsAsText {
         $lines.Add($record.topLevelComment)
         if ($null -eq $record.latestReplySummary) {
             $lines.Add("Latest reply summary: (none)")
-        } else {
+        }
+        else {
             $lines.Add(("Latest reply summary: {0}" -f $record.latestReplySummary))
         }
         $lines.Add("---")
@@ -1564,7 +1727,7 @@ function Get-UnresolvedReviewThreads {
         [string[]]$SensitiveTokens = @()
     )
 
-        $query = @'
+    $query = @'
 query GetReviewThreads(
   $owner: String!,
   $repo: String!,
@@ -1611,15 +1774,15 @@ query GetReviewThreads(
         $page++
 
         $variables = @{
-            owner = $Owner
-            repo = $Repo
+            owner    = $Owner
+            repo     = $Repo
             prNumber = $PrNumber
-            first = $PerPage
-            after = $cursor
+            first    = $PerPage
+            after    = $cursor
         }
 
         $body = @{
-            query = $query
+            query     = $query
             variables = $variables
         }
 
@@ -1630,7 +1793,8 @@ query GetReviewThreads(
             if ($response.Contains("errors")) {
                 $errors = $response["errors"]
             }
-        } elseif ($response.PSObject.Properties.Name -contains "errors") {
+        }
+        elseif ($response.PSObject.Properties.Name -contains "errors") {
             $errors = $response.errors
         }
 
@@ -1646,7 +1810,8 @@ query GetReviewThreads(
                             $message = $messageValue
                         }
                     }
-                } elseif ($firstError.PSObject.Properties.Name -contains "message") {
+                }
+                elseif ($firstError.PSObject.Properties.Name -contains "message") {
                     $messageValue = Get-FirstNonEmptyStringValue -Value $firstError.message
                     if (-not [string]::IsNullOrWhiteSpace($messageValue)) {
                         $message = $messageValue
@@ -1715,7 +1880,8 @@ query GetReviewThreads(
             if ($hasEndCursorField) {
                 $nextCursor = $pageInfo["endCursor"]
             }
-        } else {
+        }
+        else {
             $hasHasNextPageField = $pageInfo.PSObject.Properties.Name -contains "hasNextPage"
             $hasEndCursorField = $pageInfo.PSObject.Properties.Name -contains "endCursor"
             if ($hasHasNextPageField) {
@@ -1858,6 +2024,10 @@ function Invoke-Main {
     param()
 
     $overallDeadlineUtc = [datetime]::UtcNow.AddSeconds($OverallTimeoutSeconds)
+    if ($CopyStrict.IsPresent -and -not $Copy.IsPresent) {
+        throw "E_CONFIG_ERROR: -CopyStrict requires -Copy."
+    }
+
     $initialSensitive = @()
     $isGitHubHostExplicitlyProvided = $script:TopLevelBoundParameters.ContainsKey("GitHubHost")
     $allowedGitHubHostsNormalized = Get-NormalizedGitHubHostAllowlist -AllowedGitHubHosts $AllowedGitHubHosts
@@ -1894,7 +2064,8 @@ function Invoke-Main {
         }
 
         $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
-    } catch {
+    }
+    catch {
         $message = Redact-SensitiveText -Text $_.Exception.Message -SensitiveTokens $sensitiveTokens
 
         $isAuthRecoverableFailure = $message -like "E_AUTH_INVALID*" -or $message -like "E_FORBIDDEN*" -or $message -like "E_AUTH_INSUFFICIENT_SCOPE*" -or $message -like "E_AUTH_RATE_LIMITED*" -or $message -like "E_RATE_LIMIT_403*"
@@ -1925,10 +2096,12 @@ function Invoke-Main {
 
                 Validate-GitHubTokenForRepoAccess -Owner $target.Owner -Repo $target.Repo -GitHubHost $target.Host -Headers $headers -OverallDeadlineUtc $overallDeadlineUtc -RequestTimeoutSeconds $RequestTimeoutSeconds -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
                 $records = Get-UnresolvedReviewThreads -Owner $target.Owner -Repo $target.Repo -PrNumber $target.PullRequestNumber -Endpoint $endpoint -Headers $headers -GitHubHost $target.Host -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallDeadlineUtc $overallDeadlineUtc -WaitOnRateLimit:$WaitOnRateLimit -Truncate:$Truncate -AllowedGitHubHostsNormalized $allowedGitHubHostsNormalized -SensitiveTokens $sensitiveTokens
-            } else {
+            }
+            else {
                 throw $message
             }
-        } else {
+        }
+        else {
             throw $message
         }
     }
@@ -1936,12 +2109,20 @@ function Invoke-Main {
     $output = $null
     if ($OutputFormat -eq "json") {
         $output = Format-UnresolvedThreadsAsJson -Records $records
-    } else {
+    }
+    else {
         $output = Format-UnresolvedThreadsAsText -Records $records
     }
 
     if ($Copy.IsPresent) {
-        [void](Copy-ToClipboard -Text $output -SensitiveTokens $sensitiveTokens)
+        $copied = Copy-ToClipboard -Text $output -SensitiveTokens $sensitiveTokens
+        if (-not $copied -and $CopyStrict.IsPresent) {
+            throw "E_CLIPBOARD_COPY_FAILED: Clipboard copy failed and -CopyStrict was specified."
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        [void](Write-RenderedOutputToFile -Text $output -OutputPath $OutputPath -SensitiveTokens $sensitiveTokens)
     }
 
     Write-Output $output
@@ -1951,7 +2132,8 @@ function Invoke-Main {
 if (-not $NoRun.IsPresent -and $MyInvocation.InvocationName -ne ".") {
     try {
         Invoke-Main
-    } catch {
+    }
+    catch {
         Write-Error $_
         exit 1
     }

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -934,18 +934,34 @@ function Copy-ToClipboard {
                 }
                 "pbcopy" {
                     $valueToCopy | & pbcopy
+                    if ($LASTEXITCODE -ne 0) {
+                        $attemptErrors.Add("[pbcopy] exited with code $LASTEXITCODE") | Out-Null
+                        continue
+                    }
                     return $true
                 }
                 "xclip" {
                     $valueToCopy | & xclip -selection clipboard
+                    if ($LASTEXITCODE -ne 0) {
+                        $attemptErrors.Add("[xclip] exited with code $LASTEXITCODE") | Out-Null
+                        continue
+                    }
                     return $true
                 }
                 "xsel" {
                     $valueToCopy | & xsel --clipboard --input
+                    if ($LASTEXITCODE -ne 0) {
+                        $attemptErrors.Add("[xsel] exited with code $LASTEXITCODE") | Out-Null
+                        continue
+                    }
                     return $true
                 }
                 "wl-copy" {
                     $valueToCopy | & wl-copy
+                    if ($LASTEXITCODE -ne 0) {
+                        $attemptErrors.Add("[wl-copy] exited with code $LASTEXITCODE") | Out-Null
+                        continue
+                    }
                     return $true
                 }
                 default {
@@ -1029,7 +1045,7 @@ function Write-RenderedOutputToFile {
     $content = if ($null -eq $Text) { "" } else { $Text }
 
     try {
-        [System.IO.File]::WriteAllText($resolvedPath, $content, [System.Text.Encoding]::UTF8)
+        [System.IO.File]::WriteAllText($resolvedPath, $content, [System.Text.UTF8Encoding]::new($false))
         return $resolvedPath
     }
     catch {
@@ -2124,7 +2140,7 @@ function Invoke-Main {
         }
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    if ($script:TopLevelBoundParameters.ContainsKey("OutputPath")) {
         [void](Write-RenderedOutputToFile -Text $output -OutputPath $OutputPath -SensitiveTokens $sensitiveTokens)
     }
 

--- a/Scripts/Utils/GitHub/README.md
+++ b/Scripts/Utils/GitHub/README.md
@@ -50,6 +50,18 @@ Copy output to clipboard and still print it to stdout:
 pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -Copy
 ```
 
+Fail if clipboard copy does not succeed:
+
+```powershell
+pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -Copy -CopyStrict
+```
+
+Write output to a file and still print it to stdout:
+
+```powershell
+pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "https://github.com/owner/repo/pull/123" -OutputPath ./tmp/unresolved-comments.txt
+```
+
 ## Output Contract (Text)
 
 ```text
@@ -64,20 +76,30 @@ Latest reply summary: <text or (none)>
 
 - Default behavior is full (untruncated) comment and latest reply text.
 - `-Truncate` restores legacy compact output limits:
-	- top-level comments: 500 characters
-	- latest replies: 300 characters
+  - top-level comments: 500 characters
+  - latest replies: 300 characters
 - `-Copy` copies the exact rendered output (`text` or `json`) to clipboard and still writes the same output to stdout.
+- `-CopyStrict` turns clipboard copy failure into a terminating error when `-Copy` is used.
+- `-OutputPath` writes rendered output to a UTF-8 file (creating parent directories when needed) and still writes the same output to stdout.
 - Clipboard copy failures are non-fatal and emit a warning so normal output remains available.
 
 Clipboard command fallback order:
 
-1. `Set-Clipboard`
-2. `pbcopy`
-3. `xclip`
-4. `xsel`
-5. `wl-copy`
+1. `Set-Clipboard -AsOSC52` (when supported and terminal context is compatible)
+2. `Set-Clipboard`
+3. `pbcopy`
+4. `xclip`
+5. `xsel`
+6. `wl-copy`
 
 If no supported clipboard command exists, the script warns and continues.
+
+## PowerShell Completion
+
+In PowerShell terminals, parameter value completion includes:
+
+- `-OutputFormat`: `text`, `json`
+- `-GitHubHost`: `github.com`
 
 ## Migration Note
 
@@ -103,19 +125,19 @@ For `github.com`, the script also validates `X-OAuth-Scopes` and expects:
 ## Host Safety Rules
 
 - Non-global IP targets are rejected for safety, including loopback, RFC1918 private ranges,
-	link-local ranges, carrier-grade NAT ranges, multicast ranges, reserved/documentation ranges,
-	and IPv6 local/multicast equivalents.
+  link-local ranges, carrier-grade NAT ranges, multicast ranges, reserved/documentation ranges,
+  and IPv6 local/multicast equivalents.
 - `-PullRequestUrl` hosts are validated using the same safety rules.
 - If `-GitHubHost` is explicitly provided together with `-PullRequestUrl`, both hosts must
-	match after normalization or the script fails with `E_INVALID_URL`.
+  match after normalization or the script fails with `E_INVALID_URL`.
 
 Optional host allowlist controls:
 
 - `-AllowedGitHubHosts` accepts one or more approved hosts.
 - If `-AllowedGitHubHosts` is omitted, the script uses `WALLSTOP_GITHUB_ALLOWED_HOSTS`, then
-	`GITHUB_ALLOWED_HOSTS` (comma/semicolon/whitespace separated) when present.
+  `GITHUB_ALLOWED_HOSTS` (comma/semicolon/whitespace separated) when present.
 - When an allowlist is active, both target resolution and outbound request URIs must match
-	the allowlist.
+  the allowlist.
 
 Example:
 

--- a/Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1
+++ b/Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1
@@ -30,6 +30,29 @@ function ConvertTo-SkillTitle {
         [string]$FileName
     )
 
+    $knownCasing = @{
+        "github"      = "GitHub"
+        "powershell"  = "PowerShell"
+        "autohotkey"  = "AutoHotkey"
+        "applescript" = "AppleScript"
+        "macos"       = "macOS"
+        "ci"          = "CI"
+        "cd"          = "CD"
+        "llm"         = "LLM"
+        "pr"          = "PR"
+        "api"         = "API"
+        "url"         = "URL"
+        "uri"         = "URI"
+        "json"        = "JSON"
+        "yaml"        = "YAML"
+        "xml"         = "XML"
+        "html"        = "HTML"
+        "css"         = "CSS"
+        "osc52"       = "OSC52"
+        "utf8"        = "UTF-8"
+        "ahk"         = "AHK"
+    }
+
     $tokens = @($FileName -split '[-_]+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     if ($tokens.Count -eq 0) {
         return $FileName
@@ -38,7 +61,13 @@ function ConvertTo-SkillTitle {
     $textInfo = [System.Globalization.CultureInfo]::InvariantCulture.TextInfo
     $parts = @()
     foreach ($token in $tokens) {
-        $parts += $textInfo.ToTitleCase($token.ToLowerInvariant())
+        $lower = $token.ToLowerInvariant()
+        if ($knownCasing.ContainsKey($lower)) {
+            $parts += $knownCasing[$lower]
+        }
+        else {
+            $parts += $textInfo.ToTitleCase($lower)
+        }
     }
 
     return ($parts -join ' ')

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -402,9 +402,26 @@ Describe "Get-ClipboardCommand" {
     }
 }
 
+Describe "Get-ClipboardCommandPriority" {
+    It "adds OSC52 strategy before Set-Clipboard when terminal supports it" {
+        Mock Get-Command {
+            [pscustomobject]@{
+                Name = "Set-Clipboard"
+                Parameters = @{ AsOSC52 = $true }
+            }
+        } -ParameterFilter { $Name -eq "Set-Clipboard" }
+        Mock Get-Command { $null } -ParameterFilter { $Name -ne "Set-Clipboard" }
+        Mock Test-ShouldUseClipboardOsc52 { $true }
+
+        $commands = @(Get-ClipboardCommandPriority)
+        $commands[0] | Should -Be "Set-Clipboard-AsOSC52"
+        $commands[1] | Should -Be "Set-Clipboard"
+    }
+}
+
 Describe "Copy-ToClipboard" {
     It "copies text using Set-Clipboard when available" {
-        Mock Get-ClipboardCommand { "Set-Clipboard" }
+        Mock Get-ClipboardCommandPriority { @("Set-Clipboard") }
         Mock Set-Clipboard { }
 
         $copied = Copy-ToClipboard -Text "copy me"
@@ -415,7 +432,7 @@ Describe "Copy-ToClipboard" {
 
     It "returns false and warns when clipboard command is unavailable" {
         $script:lastWarningMessage = $null
-        Mock Get-ClipboardCommand { $null }
+        Mock Get-ClipboardCommandPriority { @() }
         Mock Write-Warning {
             param($Message)
             $script:lastWarningMessage = $Message
@@ -430,7 +447,7 @@ Describe "Copy-ToClipboard" {
     It "redacts sensitive tokens when clipboard copy fails" {
         $secret = "ghp_" + ("a" * 36)
         $script:lastWarningMessage = $null
-        Mock Get-ClipboardCommand { "Set-Clipboard" }
+        Mock Get-ClipboardCommandPriority { @("Set-Clipboard") }
         Mock Set-Clipboard { throw "copy failure token=$secret" }
         Mock Write-Warning {
             param($Message)
@@ -443,6 +460,53 @@ Describe "Copy-ToClipboard" {
         $script:lastWarningMessage | Should -Match "W_CLIPBOARD_COPY_FAILED"
         $script:lastWarningMessage | Should -Match "\*\*\*REDACTED\*\*\*"
         $script:lastWarningMessage | Should -Not -Match [regex]::Escape($secret)
+    }
+
+    It "falls back to secondary clipboard command when primary fails" {
+        Mock Get-ClipboardCommandPriority { @("Set-Clipboard", "Set-Clipboard-AsOSC52") }
+        Mock Set-Clipboard {
+            param(
+                [string]$Value,
+                [switch]$AsOSC52
+            )
+
+            if (-not $AsOSC52.IsPresent) {
+                throw "Set-Clipboard failed"
+            }
+        }
+
+        $copied = Copy-ToClipboard -Text "copy me"
+
+        $copied | Should -BeTrue
+        Assert-MockCalled Set-Clipboard -Times 2 -Scope It
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent }
+    }
+
+    It "uses Set-Clipboard -AsOSC52 when OSC52 strategy is selected" {
+        Mock Get-ClipboardCommandPriority { @("Set-Clipboard-AsOSC52") }
+        Mock Set-Clipboard { }
+
+        $copied = Copy-ToClipboard -Text "copy me"
+
+        $copied | Should -BeTrue
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent -and $Value -eq "copy me" }
+    }
+}
+
+Describe "Write-RenderedOutputToFile" {
+    It "writes UTF-8 output and creates missing parent directories" {
+        $tempRoot = Join-Path -Path $TestDrive -ChildPath "nested/path"
+        $targetPath = Join-Path -Path $tempRoot -ChildPath "threads.txt"
+
+        $resolvedPath = Write-RenderedOutputToFile -Text "hello" -OutputPath $targetPath
+
+        $resolvedPath | Should -Be $targetPath
+        (Test-Path -Path $targetPath -PathType Leaf) | Should -BeTrue
+        [System.IO.File]::ReadAllText($targetPath, [System.Text.Encoding]::UTF8) | Should -Be "hello"
+    }
+
+    It "throws when OutputPath is empty" {
+        { Write-RenderedOutputToFile -Text "x" -OutputPath "   " } | Should -Throw "*E_INVALID_OUTPUT_PATH*"
     }
 }
 
@@ -1843,6 +1907,118 @@ Describe "Invoke-Main" {
         $script:lastOutput | Should -Be "still output"
         Assert-MockCalled Copy-ToClipboard -Times 1 -Scope It
         Assert-MockCalled Write-Output -Times 1 -Scope It -ParameterFilter { $InputObject -eq "still output" }
+    }
+
+    It "fails fast when CopyStrict is set without Copy" {
+        $Copy = [System.Management.Automation.SwitchParameter]::new($false)
+        $CopyStrict = [System.Management.Automation.SwitchParameter]::new($true)
+
+        { Invoke-Main } | Should -Throw "*E_CONFIG_ERROR*-CopyStrict requires -Copy*"
+    }
+
+    It "throws E_CLIPBOARD_COPY_FAILED when CopyStrict is set and copy fails" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($false)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($true)
+        $CopyStrict = [System.Management.Automation.SwitchParameter]::new($true)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads {
+            @(
+                [pscustomobject]@{
+                    path = "src/a.ts"
+                    lineStart = 1
+                    lineEnd = 1
+                    topLevelComment = "x"
+                    latestReplySummary = $null
+                }
+            )
+        }
+        Mock Format-UnresolvedThreadsAsText { "strict output" }
+        Mock Copy-ToClipboard { $false }
+
+        { Invoke-Main } | Should -Throw "*E_CLIPBOARD_COPY_FAILED*"
+    }
+
+    It "writes output file when OutputPath is provided and still writes stdout" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $OutputPath = Join-Path -Path $TestDrive -ChildPath "artifacts/out.txt"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($false)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($false)
+        $CopyStrict = [System.Management.Automation.SwitchParameter]::new($false)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads {
+            @(
+                [pscustomobject]@{
+                    path = "src/a.ts"
+                    lineStart = 1
+                    lineEnd = 1
+                    topLevelComment = "x"
+                    latestReplySummary = $null
+                }
+            )
+        }
+        Mock Format-UnresolvedThreadsAsText { "file output" }
+        Mock Write-RenderedOutputToFile { $OutputPath }
+        $script:lastOutput = $null
+        Mock Write-Output {
+            param($InputObject)
+            $script:lastOutput = $InputObject
+        }
+
+        Invoke-Main
+
+        Assert-MockCalled Write-RenderedOutputToFile -Times 1 -Scope It -ParameterFilter { $OutputPath -eq (Join-Path -Path $TestDrive -ChildPath "artifacts/out.txt") -and $Text -eq "file output" }
+        $script:lastOutput | Should -Be "file output"
     }
 
     It "threads Truncate through unresolved thread retrieval" {

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -1909,6 +1909,49 @@ Describe "Invoke-Main" {
         Assert-MockCalled Write-Output -Times 1 -Scope It -ParameterFilter { $InputObject -eq "still output" }
     }
 
+    It "writes no-unresolved message when review thread retrieval returns zero objects" {
+        $PullRequestUrl = "https://github.com/org/repo/pull/5"
+        $Owner = $null
+        $Repo = $null
+        $GitHubHost = "github.com"
+        $PullRequestNumber = 0
+        $Token = "explicit-token"
+        $OutputFormat = "text"
+        $Interactive = [System.Management.Automation.SwitchParameter]::new($false)
+        $WaitOnRateLimit = [System.Management.Automation.SwitchParameter]::new($false)
+        $Truncate = [System.Management.Automation.SwitchParameter]::new($false)
+        $Copy = [System.Management.Automation.SwitchParameter]::new($false)
+        $PerPage = 100
+        $MaxPages = 100
+        $RequestTimeoutSeconds = 60
+        $OverallTimeoutSeconds = 300
+
+        Mock Resolve-PullRequestTarget {
+            [pscustomobject]@{
+                Host = "github.com"
+                Owner = "org"
+                Repo = "repo"
+                PullRequestNumber = 5
+            }
+        }
+        Mock Get-AuthToken { "auth-token" }
+        Mock Get-GitHubHeaders { @{ "Accept" = "application/json" } }
+        Mock Assert-IsHashtableLike { }
+        Mock Validate-GitHubTokenForRepoAccess { }
+        Mock Resolve-GitHubGraphQLEndpoint { "https://api.github.com/graphql" }
+        Mock Get-UnresolvedReviewThreads { @() }
+
+        $script:lastOutput = $null
+        Mock Write-Output {
+            param($InputObject)
+            $script:lastOutput = $InputObject
+        }
+
+        Invoke-Main
+
+        $script:lastOutput | Should -Be "No unresolved review threads found."
+    }
+
     It "fails fast when CopyStrict is set without Copy" {
         $Copy = [System.Management.Automation.SwitchParameter]::new($false)
         $CopyStrict = [System.Management.Automation.SwitchParameter]::new($true)

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -227,7 +227,7 @@ Describe "Get-HeaderValue" {
     }
 
     It "reads values from generic dictionary headers" {
-        $headers = [System.Collections.Generic.Dictionary[string,string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $headers = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         $headers["X-OAuth-Scopes"] = "repo"
 
         (Get-HeaderValue -Headers $headers -Key "X-OAuth-Scopes") | Should -Be "repo"
@@ -248,7 +248,8 @@ Describe "Get-HeaderValue" {
             $values.Count | Should -Be 2
             $values[0] | Should -Be "repo"
             $values[1] | Should -Be "read:org"
-        } finally {
+        }
+        finally {
             $response.Dispose()
         }
     }
@@ -261,7 +262,8 @@ Describe "Get-HeaderValue" {
             $values = @(Get-HeaderValues -Headers $response.Headers -Key "x-oauth-scopes")
             $values.Count | Should -Be 1
             $values[0] | Should -Be "repo"
-        } finally {
+        }
+        finally {
             $response.Dispose()
         }
     }
@@ -315,51 +317,51 @@ Describe "Redact-SensitiveText" {
 
     $cases = @(
         @{
-            Name = "redacts generic ghp token"
-            CaseInput = "Detected token: $ghpToken"
-            SensitiveTokens = @()
-            ShouldContain = "***REDACTED***"
-            ShouldNotContain = @($ghpToken)
+            Name              = "redacts generic ghp token"
+            CaseInput         = "Detected token: $ghpToken"
+            SensitiveTokens   = @()
+            ShouldContain     = "***REDACTED***"
+            ShouldNotContain  = @($ghpToken)
             ShouldBeUnchanged = $false
         },
         @{
-            Name = "redacts generic github_pat token"
-            CaseInput = "Detected token: $patToken"
-            SensitiveTokens = @()
-            ShouldContain = "***REDACTED***"
-            ShouldNotContain = @($patToken)
+            Name              = "redacts generic github_pat token"
+            CaseInput         = "Detected token: $patToken"
+            SensitiveTokens   = @()
+            ShouldContain     = "***REDACTED***"
+            ShouldNotContain  = @($patToken)
             ShouldBeUnchanged = $false
         },
         @{
-            Name = "redacts authorization bearer scheme"
-            CaseInput = "Authorization: Bearer $headerToken"
-            SensitiveTokens = @()
-            ShouldContain = "Authorization: Bearer ***REDACTED***"
-            ShouldNotContain = @($headerToken)
+            Name              = "redacts authorization bearer scheme"
+            CaseInput         = "Authorization: Bearer $headerToken"
+            SensitiveTokens   = @()
+            ShouldContain     = "Authorization: Bearer ***REDACTED***"
+            ShouldNotContain  = @($headerToken)
             ShouldBeUnchanged = $false
         },
         @{
-            Name = "redacts authorization token scheme"
-            CaseInput = "Authorization: token $headerToken"
-            SensitiveTokens = @()
-            ShouldContain = "Authorization: token ***REDACTED***"
-            ShouldNotContain = @($headerToken)
+            Name              = "redacts authorization token scheme"
+            CaseInput         = "Authorization: token $headerToken"
+            SensitiveTokens   = @()
+            ShouldContain     = "Authorization: token ***REDACTED***"
+            ShouldNotContain  = @($headerToken)
             ShouldBeUnchanged = $false
         },
         @{
-            Name = "does not redact too short ghp token"
-            CaseInput = "Detected token: ghp_abc123"
-            SensitiveTokens = @()
-            ShouldContain = "Detected token: ghp_abc123"
-            ShouldNotContain = @()
+            Name              = "does not redact too short ghp token"
+            CaseInput         = "Detected token: ghp_abc123"
+            SensitiveTokens   = @()
+            ShouldContain     = "Detected token: ghp_abc123"
+            ShouldNotContain  = @()
             ShouldBeUnchanged = $true
         },
         @{
-            Name = "does not redact regex literal documentation string"
-            CaseInput = '$redacted = $redacted -replace "ghp_[A-Za-z0-9]{36}", "***REDACTED***"'
-            SensitiveTokens = @()
-            ShouldContain = 'ghp_[A-Za-z0-9]{36}'
-            ShouldNotContain = @()
+            Name              = "does not redact regex literal documentation string"
+            CaseInput         = '$redacted = $redacted -replace "ghp_[A-Za-z0-9]{36}", "***REDACTED***"'
+            SensitiveTokens   = @()
+            ShouldContain     = 'ghp_[A-Za-z0-9]{36}'
+            ShouldNotContain  = @()
             ShouldBeUnchanged = $true
         }
     )
@@ -371,7 +373,8 @@ Describe "Redact-SensitiveText" {
 
         if ($ShouldBeUnchanged) {
             $redacted | Should -BeExactly $CaseInput
-        } else {
+        }
+        else {
             $redacted | Should -Not -BeExactly $CaseInput
         }
 
@@ -406,7 +409,7 @@ Describe "Get-ClipboardCommandPriority" {
     It "adds OSC52 strategy before Set-Clipboard when terminal supports it" {
         Mock Get-Command {
             [pscustomobject]@{
-                Name = "Set-Clipboard"
+                Name       = "Set-Clipboard"
                 Parameters = @{ AsOSC52 = $true }
             }
         } -ParameterFilter { $Name -eq "Set-Clipboard" }
@@ -462,24 +465,30 @@ Describe "Copy-ToClipboard" {
         $script:lastWarningMessage | Should -Not -Match [regex]::Escape($secret)
     }
 
-    It "falls back to secondary clipboard command when primary fails" {
-        Mock Get-ClipboardCommandPriority { @("Set-Clipboard", "Set-Clipboard-AsOSC52") }
+    It "falls back to Set-Clipboard when OSC52 attempt fails" {
+        $script:clipboardAttemptOrder = @()
+        Mock Get-ClipboardCommandPriority { @("Set-Clipboard-AsOSC52", "Set-Clipboard") }
         Mock Set-Clipboard {
             param(
                 [string]$Value,
                 [switch]$AsOSC52
             )
 
-            if (-not $AsOSC52.IsPresent) {
-                throw "Set-Clipboard failed"
+            if ($AsOSC52.IsPresent) {
+                $script:clipboardAttemptOrder += "Set-Clipboard-AsOSC52"
+                throw "Set-Clipboard -AsOSC52 failed"
             }
+
+            $script:clipboardAttemptOrder += "Set-Clipboard"
         }
 
         $copied = Copy-ToClipboard -Text "copy me"
 
         $copied | Should -BeTrue
+        (($script:clipboardAttemptOrder) -join ",") | Should -Be "Set-Clipboard-AsOSC52,Set-Clipboard" -Because "clipboard fallback should preserve OSC52-first attempt order and then recover with plain Set-Clipboard"
         Assert-MockCalled Set-Clipboard -Times 2 -Scope It
         Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent }
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { -not $AsOSC52.IsPresent }
     }
 
     It "uses Set-Clipboard -AsOSC52 when OSC52 strategy is selected" {
@@ -490,6 +499,64 @@ Describe "Copy-ToClipboard" {
 
         $copied | Should -BeTrue
         Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent -and $Value -eq "copy me" }
+    }
+
+    It "falls back across native clipboard tools in priority order" {
+        $script:nativeClipboardAttemptOrder = @()
+        Mock Get-ClipboardCommandPriority { @("pbcopy", "xclip", "xsel") }
+        try {
+            function pbcopy {
+                param(
+                    [Parameter(ValueFromPipeline = $true)]
+                    [AllowNull()]
+                    [string]$InputObject
+                )
+
+                process {
+                    $script:nativeClipboardAttemptOrder += "pbcopy"
+                    $global:LASTEXITCODE = 17
+                }
+            }
+
+            function xclip {
+                param(
+                    [string]$selection,
+                    [Parameter(ValueFromPipeline = $true)]
+                    [AllowNull()]
+                    [string]$InputObject
+                )
+
+                process {
+                    $script:nativeClipboardAttemptOrder += "xclip"
+                    $global:LASTEXITCODE = 42
+                }
+            }
+
+            function xsel {
+                param(
+                    [string]$clipboard,
+                    [string]$input,
+                    [Parameter(ValueFromPipeline = $true)]
+                    [AllowNull()]
+                    [string]$InputObject
+                )
+
+                process {
+                    $script:nativeClipboardAttemptOrder += "xsel"
+                    $global:LASTEXITCODE = 0
+                }
+            }
+
+            $copied = Copy-ToClipboard -Text "copy me"
+
+            $copied | Should -BeTrue
+            (($script:nativeClipboardAttemptOrder) -join ",") | Should -Be "pbcopy,xclip,xsel" -Because "native fallback should continue through failed tools and stop after the first success"
+        }
+        finally {
+            Remove-Item -Path Function:pbcopy -ErrorAction SilentlyContinue
+            Remove-Item -Path Function:xclip -ErrorAction SilentlyContinue
+            Remove-Item -Path Function:xsel -ErrorAction SilentlyContinue
+        }
     }
 }
 
@@ -513,12 +580,12 @@ Describe "Write-RenderedOutputToFile" {
 Describe "Convert-ReviewThreadToOutputRecord" {
     It "returns null for resolved threads" {
         $thread = [pscustomobject]@{
-            id = "T_x"
+            id         = "T_x"
             isResolved = $true
-            path = "src/file.ps1"
-            startLine = 10
-            line = 11
-            comments = [pscustomobject]@{
+            path       = "src/file.ps1"
+            startLine  = 10
+            line       = 11
+            comments   = [pscustomobject]@{
                 nodes = @([pscustomobject]@{ body = "hello" })
             }
         }
@@ -529,12 +596,12 @@ Describe "Convert-ReviewThreadToOutputRecord" {
 
     It "maps unresolved thread fields" {
         $thread = [pscustomobject]@{
-            id = "THREAD_1"
+            id         = "THREAD_1"
             isResolved = $false
-            path = "src/main.ts"
-            startLine = 10
-            line = 12
-            comments = [pscustomobject]@{
+            path       = "src/main.ts"
+            startLine  = 10
+            line       = 12
+            comments   = [pscustomobject]@{
                 nodes = @(
                     [pscustomobject]@{ body = "Top level comment" },
                     [pscustomobject]@{ body = "Reply summary" }
@@ -553,12 +620,12 @@ Describe "Convert-ReviewThreadToOutputRecord" {
 
     It "throws when comments nodes is not array-wrapped" {
         $thread = [pscustomobject]@{
-            id = "THREAD_SINGLE"
+            id         = "THREAD_SINGLE"
             isResolved = $false
-            path = "src/single.ts"
-            startLine = 21
-            line = 21
-            comments = [pscustomobject]@{
+            path       = "src/single.ts"
+            startLine  = 21
+            line       = 21
+            comments   = [pscustomobject]@{
                 nodes = [pscustomobject]@{ body = "Single comment only" }
             }
         }
@@ -572,12 +639,12 @@ Describe "Convert-ReviewThreadToOutputRecord" {
         $topBody = "x" * 600
         $replyBody = "y" * 400
         $thread = [pscustomobject]@{
-            id = "THREAD_LONG"
+            id         = "THREAD_LONG"
             isResolved = $false
-            path = "src/long.ts"
-            startLine = 5
-            line = 9
-            comments = [pscustomobject]@{
+            path       = "src/long.ts"
+            startLine  = 5
+            line       = 9
+            comments   = [pscustomobject]@{
                 nodes = @(
                     [pscustomobject]@{ body = $topBody },
                     [pscustomobject]@{ body = $replyBody }
@@ -596,12 +663,12 @@ Describe "Convert-ReviewThreadToOutputRecord" {
         $topBody = "x" * 600
         $replyBody = "y" * 400
         $thread = [pscustomobject]@{
-            id = "THREAD_TRUNCATE"
+            id         = "THREAD_TRUNCATE"
             isResolved = $false
-            path = "src/long.ts"
-            startLine = 5
-            line = 9
-            comments = [pscustomobject]@{
+            path       = "src/long.ts"
+            startLine  = 5
+            line       = 9
+            comments   = [pscustomobject]@{
                 nodes = @(
                     [pscustomobject]@{ body = $topBody },
                     [pscustomobject]@{ body = $replyBody }
@@ -621,28 +688,28 @@ Describe "Format-UnresolvedThreadsAsText" {
     It "renders exact delimiter contract" {
         $records = @(
             [pscustomobject]@{
-                path = "src/a.ts"
-                lineStart = 8
-                lineEnd = 8
-                topLevelComment = "Comment A"
+                path               = "src/a.ts"
+                lineStart          = 8
+                lineEnd            = 8
+                topLevelComment    = "Comment A"
                 latestReplySummary = $null
-                threadId = "1"
-                prNumber = 1
-                owner = "o"
-                repo = "r"
-                url = "https://github.com/o/r/pull/1"
+                threadId           = "1"
+                prNumber           = 1
+                owner              = "o"
+                repo               = "r"
+                url                = "https://github.com/o/r/pull/1"
             },
             [pscustomobject]@{
-                path = "src/b.ts"
-                lineStart = 12
-                lineEnd = 20
-                topLevelComment = "Comment B"
+                path               = "src/b.ts"
+                lineStart          = 12
+                lineEnd            = 20
+                topLevelComment    = "Comment B"
                 latestReplySummary = "Reply B"
-                threadId = "2"
-                prNumber = 1
-                owner = "o"
-                repo = "r"
-                url = "https://github.com/o/r/pull/1"
+                threadId           = "2"
+                prNumber           = 1
+                owner              = "o"
+                repo               = "r"
+                url                = "https://github.com/o/r/pull/1"
             }
         )
 
@@ -1213,9 +1280,9 @@ Describe "Get-UnresolvedReviewThreads" {
                             pullRequest = @{
                                 reviewThreads = @{
                                     pageInfo = @{ hasNextPage = $true; endCursor = "CURSOR_1" }
-                                    nodes = @(
+                                    nodes    = @(
                                         @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @(@{ body = "A" }, @{ body = "A reply" }) } },
-                                        @{ id = "T2"; isResolved = $true;  path = "src/b.ts"; startLine = 2; line = 2; comments = @{ nodes = @(@{ body = "B" }) } }
+                                        @{ id = "T2"; isResolved = $true; path = "src/b.ts"; startLine = 2; line = 2; comments = @{ nodes = @(@{ body = "B" }) } }
                                     )
                                 }
                             }
@@ -1230,7 +1297,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $false; endCursor = $null }
-                                nodes = @(
+                                nodes    = @(
                                     @{ id = "T3"; isResolved = $false; path = "src/c.ts"; startLine = 3; line = 4; comments = @{ nodes = @(@{ body = "C" }) } }
                                 )
                             }
@@ -1257,7 +1324,8 @@ Describe "Get-UnresolvedReviewThreads" {
         $thrown = $null
         try {
             [void](Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)) -SensitiveTokens @($secret))
-        } catch {
+        }
+        catch {
             $thrown = $_.Exception.Message
         }
 
@@ -1273,7 +1341,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $false; endCursor = $null }
-                                nodes = @{ id = "T1" }
+                                nodes    = @{ id = "T1" }
                             }
                         }
                     }
@@ -1294,7 +1362,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $false; endCursor = $null }
-                                nodes = @(
+                                nodes    = @(
                                     @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @{ body = "not-array" } } }
                                 )
                             }
@@ -1317,7 +1385,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ endCursor = $null }
-                                nodes = @()
+                                nodes    = @()
                             }
                         }
                     }
@@ -1338,7 +1406,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $true; endCursor = 42 }
-                                nodes = @()
+                                nodes    = @()
                             }
                         }
                     }
@@ -1362,7 +1430,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $false; endCursor = $null }
-                                nodes = @(
+                                nodes    = @(
                                     @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @(@{ body = $topBody }, @{ body = $replyBody }) } }
                                 )
                             }
@@ -1389,7 +1457,7 @@ Describe "Get-UnresolvedReviewThreads" {
                         pullRequest = @{
                             reviewThreads = @{
                                 pageInfo = @{ hasNextPage = $false; endCursor = $null }
-                                nodes = @(
+                                nodes    = @(
                                     @{ id = "T1"; isResolved = $false; path = "src/a.ts"; startLine = 1; line = 1; comments = @{ nodes = @(@{ body = $topBody }, @{ body = $replyBody }) } }
                                 )
                             }
@@ -1498,9 +1566,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1512,10 +1580,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/main.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "hello"
+                    path               = "src/main.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "hello"
                     latestReplySummary = $null
                 }
             )
@@ -1551,9 +1619,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1583,10 +1651,10 @@ Describe "Invoke-Main" {
 
             return @(
                 [pscustomobject]@{
-                    path = "src/recovered.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "Recovered"
+                    path               = "src/recovered.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "Recovered"
                     latestReplySummary = $null
                 }
             )
@@ -1630,9 +1698,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1662,10 +1730,10 @@ Describe "Invoke-Main" {
 
             return @(
                 [pscustomobject]@{
-                    path = "src/recovered.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "Recovered"
+                    path               = "src/recovered.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "Recovered"
                     latestReplySummary = $null
                 }
             )
@@ -1704,9 +1772,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1737,10 +1805,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/recovered.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "Recovered"
+                    path               = "src/recovered.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "Recovered"
                     latestReplySummary = $null
                 }
             )
@@ -1779,9 +1847,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1817,9 +1885,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1831,10 +1899,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/a.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "x"
+                    path               = "src/a.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "x"
                     latestReplySummary = $null
                 }
             )
@@ -1872,9 +1940,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1886,10 +1954,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/a.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "x"
+                    path               = "src/a.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "x"
                     latestReplySummary = $null
                 }
             )
@@ -1928,9 +1996,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1979,9 +2047,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -1993,10 +2061,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/a.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "x"
+                    path               = "src/a.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "x"
                     latestReplySummary = $null
                 }
             )
@@ -2029,9 +2097,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -2043,10 +2111,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/a.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "x"
+                    path               = "src/a.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "x"
                     latestReplySummary = $null
                 }
             )
@@ -2085,9 +2153,9 @@ Describe "Invoke-Main" {
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
-                Host = "github.com"
-                Owner = "org"
-                Repo = "repo"
+                Host              = "github.com"
+                Owner             = "org"
+                Repo              = "repo"
                 PullRequestNumber = 5
             }
         }
@@ -2099,10 +2167,10 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads {
             @(
                 [pscustomobject]@{
-                    path = "src/a.ts"
-                    lineStart = 1
-                    lineEnd = 1
-                    topLevelComment = "x"
+                    path               = "src/a.ts"
+                    lineStart          = 1
+                    lineEnd            = 1
+                    topLevelComment    = "x"
                     latestReplySummary = $null
                 }
             )
@@ -2119,18 +2187,18 @@ Describe "Invoke-Main" {
 Describe "Strict-mode collection shape safety" {
     It "normalizes analyzer-like output for <CaseLabel>" -ForEach @(
         @{
-            CaseLabel = "null output"
-            InputValue = $null
+            CaseLabel     = "null output"
+            InputValue    = $null
             ExpectedCount = 0
         },
         @{
-            CaseLabel = "single object output"
-            InputValue = [pscustomobject]@{ RuleName = "RuleA" }
+            CaseLabel     = "single object output"
+            InputValue    = [pscustomobject]@{ RuleName = "RuleA" }
             ExpectedCount = 1
         },
         @{
-            CaseLabel = "multiple object output"
-            InputValue = @(
+            CaseLabel     = "multiple object output"
+            InputValue    = @(
                 [pscustomobject]@{ RuleName = "RuleA" },
                 [pscustomobject]@{ RuleName = "RuleB" }
             )

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -2025,6 +2025,7 @@ Describe "Invoke-Main" {
         $MaxPages = 100
         $RequestTimeoutSeconds = 60
         $OverallTimeoutSeconds = 300
+        $script:TopLevelBoundParameters = @{ "OutputPath" = $OutputPath }
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{
@@ -2080,6 +2081,7 @@ Describe "Invoke-Main" {
         $MaxPages = 100
         $RequestTimeoutSeconds = 60
         $OverallTimeoutSeconds = 300
+        $script:TopLevelBoundParameters = @{}
 
         Mock Resolve-PullRequestTarget {
             [pscustomobject]@{

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -260,6 +260,27 @@ Describe "Scope safety conventions" {
         $testsContent | Should -Match 'allowed GitHub host list'
     }
 
+    It "keeps clipboard strict-mode and output-file contracts for unresolved PR comments" {
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
+
+        $content | Should -Match '\[switch\]\$CopyStrict'
+        $content | Should -Match '\[Alias\("OutFile"\)\]\s*\r?\n\s*\[string\]\$OutputPath'
+        $content | Should -Match 'if\s*\(\$CopyStrict\.IsPresent\s*-and\s*-not\s*\$Copy\.IsPresent\)\s*\{\s*throw\s+"E_CONFIG_ERROR: -CopyStrict requires -Copy\."'
+        $content | Should -Match 'if\s*\(\$Copy\.IsPresent\)\s*\{[\s\S]*E_CLIPBOARD_COPY_FAILED'
+        $content | Should -Match 'function\s+Write-RenderedOutputToFile'
+        $content | Should -Match 'Write-RenderedOutputToFile\s+-Text\s+\$output\s+-OutputPath\s+\$OutputPath'
+        $content | Should -Match '\[System\.IO\.File\]::WriteAllText\(\$resolvedPath,\s*\$content,\s*\[System\.Text\.Encoding\]::UTF8\)'
+    }
+
+    It "keeps PowerShell argument-completion metadata for unresolved PR comments" {
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
+
+        $content | Should -Match '\[ArgumentCompletions\("github\.com"\)\]'
+        $content | Should -Match '\[ArgumentCompletions\("text",\s*"json"\)\]'
+    }
+
     It "keeps Increment-Version direct-run invocation guard" {
         $incrementPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Increment-Version.ps1"
         $incrementContent = Get-Content -Path $incrementPath -Raw

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -285,6 +285,23 @@ Describe "Scope safety conventions" {
         }
     }
 
+    It "keeps OSC52-first ordering in clipboard command priority" {
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
+
+        $functionMatch = [regex]::Match($content, 'function\s+Get-ClipboardCommandPriority\s*\{(?<body>[\s\S]*?)^\}', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+        $functionMatch.Success | Should -BeTrue -Because "Get-ClipboardCommandPriority should exist so clipboard ordering contracts can be validated"
+        $functionBody = $functionMatch.Groups["body"].Value
+
+        $functionBody | Should -Match 'if\s*\(\$supportsOsc52\s*-and\s*\(Test-ShouldUseClipboardOsc52\)\)' -Because "OSC52 strategy must remain explicitly gated by capability and terminal-context checks"
+
+        $osc52AddIndex = $functionBody.IndexOf('$commands.Add("Set-Clipboard-AsOSC52")', [System.StringComparison]::Ordinal)
+        $setClipboardAddIndex = $functionBody.IndexOf('$commands.Add("Set-Clipboard")', [System.StringComparison]::Ordinal)
+        $osc52AddIndex | Should -BeGreaterThan -1 -Because "Get-ClipboardCommandPriority must include Set-Clipboard-AsOSC52"
+        $setClipboardAddIndex | Should -BeGreaterThan -1 -Because "Get-ClipboardCommandPriority must include Set-Clipboard"
+        $osc52AddIndex | Should -BeLessThan $setClipboardAddIndex -Because "clipboard strategy order is a behavior contract: OSC52 attempt must run before plain Set-Clipboard"
+    }
+
     It "uses PSBoundParameters for OutputPath gating in Invoke-Main" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
         $content = Get-Content -Path $fullPath -Raw

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -270,7 +270,27 @@ Describe "Scope safety conventions" {
         $content | Should -Match 'if\s*\(\$Copy\.IsPresent\)\s*\{[\s\S]*E_CLIPBOARD_COPY_FAILED'
         $content | Should -Match 'function\s+Write-RenderedOutputToFile'
         $content | Should -Match 'Write-RenderedOutputToFile\s+-Text\s+\$output\s+-OutputPath\s+\$OutputPath'
-        $content | Should -Match '\[System\.IO\.File\]::WriteAllText\(\$resolvedPath,\s*\$content,\s*\[System\.Text\.Encoding\]::UTF8\)'
+        $content | Should -Match '\[System\.IO\.File\]::WriteAllText\(\$resolvedPath,\s*\$content,\s*\[System\.Text\.UTF8Encoding\]::new\(\$false\)\)'
+    }
+
+    It "checks LASTEXITCODE after native clipboard commands in Copy-ToClipboard" {
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
+
+        foreach ($tool in @("pbcopy", "xclip", "xsel", "wl-copy")) {
+            $escapedTool = [regex]::Escape($tool)
+            $content | Should -Match (
+                "function\s+Copy-ToClipboard[\s\S]*""$escapedTool""\s*\{[\s\S]*?LASTEXITCODE\s+-ne\s+0[\s\S]*?continue[\s\S]*?return\s+\`$true"
+            ) -Because "Copy-ToClipboard must check LASTEXITCODE after '$tool' to detect silent native command failures"
+        }
+    }
+
+    It "uses PSBoundParameters for OutputPath gating in Invoke-Main" {
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
+
+        $content | Should -Match 'function\s+Invoke-Main[\s\S]*TopLevelBoundParameters\.ContainsKey\("OutputPath"\)'
+        $content | Should -Not -Match 'function\s+Invoke-Main[\s\S]*IsNullOrWhiteSpace\(\$OutputPath\)[\s\S]*Write-RenderedOutputToFile'
     }
 
     It "keeps PowerShell argument-completion metadata for unresolved PR comments" {
@@ -1428,6 +1448,41 @@ Describe "GitHub output and clipboard conventions" {
         $testsContent = Get-Content -Path $testsPath -Raw
 
         $testsContent | Should -Match 'writes stdout output even when copy fails'
+    }
+}
+
+Describe "UTF-8 encoding conventions" {
+    It "uses no-BOM UTF-8 for all WriteAllText calls in production scripts" {
+        $scriptsRoot = Join-Path -Path $script:repoRoot -ChildPath "Scripts"
+        $scripts = Get-ChildItem -Path $scriptsRoot -Filter "*.ps1" -File -Recurse -ErrorAction Stop
+        $violations = New-Object System.Collections.Generic.List[string]
+
+        foreach ($scriptFile in $scripts) {
+            $lines = @(Get-Content -Path $scriptFile.FullName)
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                if ($lines[$i] -match 'WriteAllText\(' -and $lines[$i] -match '\[System\.Text\.Encoding\]::UTF8') {
+                    $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $violations.Add("${relative}:$($i + 1)") | Out-Null
+                }
+            }
+        }
+
+        $violations.Count | Should -Be 0 -Because (
+            "WriteAllText must use [System.Text.UTF8Encoding]::new(`$false) (no BOM) instead of [System.Text.Encoding]::UTF8 (emits BOM). Violations: {0}" -f ($violations -join ', ')
+        )
+    }
+}
+
+Describe "Skills index generation conventions" {
+    It "includes a known-casing dictionary in ConvertTo-SkillTitle" {
+        $indexGeneratorPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1"
+        $content = Get-Content -Path $indexGeneratorPath -Raw
+
+        $content | Should -Match 'function\s+ConvertTo-SkillTitle[\s\S]*\$knownCasing'
+        $content | Should -Match '\$knownCasing\.ContainsKey\('
+        foreach ($term in @("github", "powershell", "pr", "api", "ci", "llm")) {
+            $content | Should -Match "`"$term`"\s*=" -Because "knownCasing dictionary must include '$term' to prevent incorrect title casing"
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Improves `Get-UnresolvedPRComments.ps1` with a more robust clipboard copy mechanism, a new strict-mode flag, and the ability to write output directly to a file — while keeping stdout output unchanged for automation compatibility.

## What Changed

### New clipboard fallback chain (`-Copy`)

The clipboard copy mechanism now tries multiple strategies in order, stopping at the first success:

1. `Set-Clipboard -AsOSC52` (when supported and terminal context is compatible)
2. `Set-Clipboard`
3. `pbcopy` (macOS)
4. `xclip` (Linux/X11)
5. `xsel` (Linux/X11)
6. `wl-copy` (Linux/Wayland)

Copy failures remain non-fatal by default and emit a warning.

### New `-CopyStrict` flag

When `-CopyStrict` is used together with `-Copy`, a clipboard copy failure becomes a terminating error (`E_CLIPBOARD_COPY_FAILED`). Using `-CopyStrict` without `-Copy` fails fast with a clear config error.

```powershell
# Fail if clipboard copy does not succeed
pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "..." -Copy -CopyStrict
```

### New `-OutputPath` / `-OutFile` parameter

Write rendered output to a UTF-8 file in addition to stdout. Parent directories are created automatically.

```powershell
# Write to file and still print to stdout
pwsh ./Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1 -PullRequestUrl "..." -OutputPath ./tmp/unresolved-comments.txt
```

### PowerShell completion hints

`-OutputFormat` and `-GitHubHost` now expose `[ArgumentCompletions(...)]` metadata for better tab-completion in PowerShell terminals.

## Tests

New unit tests cover:
- OSC52-first clipboard priority ordering
- Fallback to secondary clipboard command when the primary fails
- `-CopyStrict` fast-fail without `-Copy`
- `-CopyStrict` throwing on copy failure
- `-OutputPath` writing UTF-8 output and creating missing parent directories
- Output file path written while stdout is preserved
- Policy/safety convention tests for new parameter contracts

## Files Changed

| File | Change |
|------|--------|
| `Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1` | Core clipboard, strict mode, and file output logic |
| `Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1` | New unit tests |
| `Tests/Utils/ScriptSafetyConventions.Tests.ps1` | New policy tests for parameter contracts |
| `Scripts/Utils/GitHub/README.md` | Updated usage examples |
| `.llm/skill-details/github-pr-unresolved-comments.md` | Updated LLM skill docs |
| `.llm/skills-index.md` | Index update |
| `README.md` | Minor docs update |
