### PR TITLE
Powershell compatibility

### DIFF
--- a/.github/workflows/script-quality.yml
+++ b/.github/workflows/script-quality.yml
@@ -504,6 +504,130 @@ jobs:
         shell: pwsh
         run: ./Scripts/Utils/Quality/Assert-CleanGitTree.ps1 -Context "macOS language checks"
 
+  powershell-compat-analyzer:
+    name: PowerShell cross-version compat gate (static)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+            Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+          }
+
+      - name: Run cross-version compatibility gate (5.1 + 7+)
+        shell: pwsh
+        run: ./Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
+
+  powershell-tests-winps51:
+    name: PowerShell tests (Windows PowerShell 5.1)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Report PowerShell edition under test
+        shell: powershell
+        run: |
+          Write-Host ("Edition: {0}  Version: {1}" -f $PSVersionTable.PSEdition, $PSVersionTable.PSVersion)
+
+      - name: Install Pester 5 and PSScriptAnalyzer (Windows PowerShell 5.1)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          # Windows PowerShell 5.1 ships Pester 3.4 and needs TLS 1.2 + the NuGet provider
+          # + a trusted gallery before Install-Module.
+          [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+          Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          # PSScriptAnalyzer is required by formatter/quality tests that the suite exercises.
+          Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+
+      - name: Run Pester suite under Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+          $configuration = New-PesterConfiguration
+          $configuration.Run.Path = "Tests"
+          $configuration.Run.PassThru = $true
+          $configuration.Output.Verbosity = "Detailed"
+          $configuration.TestResult.Enabled = $true
+          $configuration.TestResult.OutputPath = "testresults-winps51.xml"
+          $result = Invoke-Pester -Configuration $configuration
+          Write-Host ("RESULT [WinPS5.1] Total={0} Passed={1} Failed={2} Skipped={3}" -f $result.TotalCount, $result.PassedCount, $result.FailedCount, $result.SkippedCount)
+          if ($result.FailedCount -gt 0) {
+            throw "E_CROSSVERSION_TESTS_FAILED: $($result.FailedCount) test(s) failed under Windows PowerShell 5.1."
+          }
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: pester-winps51
+          path: testresults-winps51.xml
+          if-no-files-found: ignore
+
+  powershell-tests-pwsh7:
+    name: PowerShell tests (PowerShell 7+)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Report PowerShell edition under test
+        shell: pwsh
+        run: |
+          Write-Host ("Edition: {0}  Version: {1}" -f $PSVersionTable.PSEdition, $PSVersionTable.PSVersion)
+
+      - name: Install Pester 5 and PSScriptAnalyzer (PowerShell 7+)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+          # PSScriptAnalyzer is required by formatter/quality tests that the suite exercises.
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+            Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+
+      - name: Run Pester suite under PowerShell 7+
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+          $configuration = New-PesterConfiguration
+          $configuration.Run.Path = "Tests"
+          $configuration.Run.PassThru = $true
+          $configuration.Output.Verbosity = "Detailed"
+          $configuration.TestResult.Enabled = $true
+          $configuration.TestResult.OutputPath = "testresults-pwsh7.xml"
+          $result = Invoke-Pester -Configuration $configuration
+          Write-Host ("RESULT [PS7+] Total={0} Passed={1} Failed={2} Skipped={3}" -f $result.TotalCount, $result.PassedCount, $result.FailedCount, $result.SkippedCount)
+          if ($result.FailedCount -gt 0) {
+            throw "E_CROSSVERSION_TESTS_FAILED: $($result.FailedCount) test(s) failed under PowerShell 7+."
+          }
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: pester-pwsh7
+          path: testresults-pwsh7.xml
+          if-no-files-found: ignore
+
   validation-summary:
     name: Validation summary
     if: ${{ always() }}
@@ -512,6 +636,9 @@ jobs:
       - windows-language
       - windows-language-nightly
       - macos-language
+      - powershell-compat-analyzer
+      - powershell-tests-winps51
+      - powershell-tests-pwsh7
     runs-on: ubuntu-latest
 
     steps:
@@ -526,6 +653,9 @@ jobs:
             "windows-language"       = "${{ needs.windows-language.result }}"
             "windows-language-nightly" = "${{ needs.windows-language-nightly.result }}"
             "macos-language"         = "${{ needs.macos-language.result }}"
+            "powershell-compat-analyzer" = "${{ needs.powershell-compat-analyzer.result }}"
+            "powershell-tests-winps51" = "${{ needs.powershell-tests-winps51.result }}"
+            "powershell-tests-pwsh7" = "${{ needs.powershell-tests-pwsh7.result }}"
           }
 
           $failedLanes = @()

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -184,15 +184,41 @@ array semantics in empty-result paths.
 - Add both behavioral and structural coverage for high-risk array-return helpers: behavior tests for empty/non-empty flattening plus AST/pattern checks that call-site wrapper usage matches the helper's return contract.
 - A convention test in `ScriptSafetyConventions.Tests.ps1` enforces this in `Scripts/`.
 
-## Cross-Platform PowerShell Portability
+## Cross-Platform And Cross-Version PowerShell Portability
 
-Scripts under `Scripts/Utils/` must run on Windows, macOS, and Linux with PowerShell 7+.
+All repository PowerShell (`Scripts/**`, `Config/Powershell/**`, `Tests/**`) must run on
+BOTH Windows PowerShell 5.1 (Desktop edition / .NET Framework) AND PowerShell 7+ (Core),
+across Windows, macOS, and Linux. The cross-version contract is enforced statically by
+`Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1` (PSScriptAnalyzer
+`PSUseCompatible*` rules over 5.1 + 7 profiles, plus an AST scan for 5.1-undefined
+automatic variables) and at runtime by the `powershell-tests-winps51` / `powershell-tests-pwsh7`
+CI lanes that execute the Pester suite under each edition. Re-divergence is policy-tested
+in `Tests/Utils/CompatibilityConventions.Tests.ps1` and `Tests/Utils/CompatibilityHelpers.Tests.ps1`.
+
+Portable idioms are single-sourced in `Scripts/Utils/Common/CompatibilityHelpers.ps1`
+(dot-source it; never reintroduce the raw construct):
+
+- `$IsWindows`/`$IsMacOS`/`$IsLinux` are undefined on 5.1 and THROW under `Set-StrictMode`;
+  use `Test-IsWindowsPlatform`/`Test-IsMacOSPlatform`/`Test-IsLinuxPlatform`.
+- `[System.IO.Path]::GetRelativePath` is absent on .NET Framework; use `Get-RelativePathCompat`.
+- `ConvertTo-Json -AsArray` (6+) → `ConvertTo-JsonArrayCompat`; `ConvertFrom-Json -Depth/-NoEnumerate`
+  (6+) → `ConvertFrom-JsonCompat`. `New-Item -LiteralPath` is invalid on every edition; create
+  directories with `[System.IO.Directory]::CreateDirectory($path)` (literal, idempotent).
+- `[ArgumentCompletions()]`, ternary `?:`, `??`/`??=`, `&&`/`||`, `clean{}`, `$PSStyle` are 7+-only;
+  use `[ValidateSet]`, `if/else`, `try/finally`. Interactive profiles must guard PSReadLine 2.2+
+  options (`-PredictionSource`/`-PredictionViewStyle`) behind a capability probe.
+- Runtime-guarded/floor-safe constructs (for example `Set-Clipboard -AsOSC52`,
+  `RuntimeInformation::ProcessArchitecture`) keep an inline justified `SuppressMessageAttribute`;
+  external executables and Pester DSL live in `compatibility-allowlist.psd1`. Never allowlist a
+  real cmdlet whose parameters differ across editions.
+
+The portability rules below also apply (PowerShell 7+ remains the primary cross-platform target):
 
 1. Use `Join-Path` and `[System.IO.Path]` for path construction; never hardcode `\` or `/`.
-2. Use `$IsWindows`, `$IsMacOS`, `$IsLinux` for OS branching; avoid `$env:OS` checks.
+2. Use the `Test-IsWindowsPlatform`/`Test-IsMacOSPlatform`/`Test-IsLinuxPlatform` helpers for OS branching (never bare `$IsWindows`/`$IsMacOS`/`$IsLinux`, which throw on 5.1; never `$env:OS`).
 3. Write files with explicit UTF-8 no-BOM encoding via `[System.IO.File]::WriteAllText(..., [System.Text.UTF8Encoding]::new($false))`.
 4. Normalize line endings (`-replace "\r", ''`) before regex matching or string comparison.
-5. Normalize path separators to `/` in generated output for deterministic cross-OS comparison. For custom output objects that include a `Path` field (for example violation and diagnostics records), normalize immediately after `GetRelativePath` before returning or logging.
+5. Normalize path separators to `/` in generated output for deterministic cross-OS comparison. For custom output objects that include a `Path` field (for example violation and diagnostics records), normalize immediately after `Get-RelativePathCompat` (the portable relative-path helper) before returning or logging.
 6. Policy tests that validate code structure must be formatter-tolerant: avoid exact-literal `.Contains(...)` checks for syntax-sensitive snippets (for example spacing around operators), and prefer semantic/regex assertions that tolerate whitespace drift while still enforcing behavior.
 7. Use `[System.IO.Path]::GetTempPath()` instead of `$env:TEMP` for portable temp directories.
 8. Use exact file name casing; Linux file systems are case-sensitive.

--- a/Config/Powershell/CurrentUserCurrentHost_Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/CurrentUserCurrentHost_Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,17 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-PSReadLineOption -PredictionSource/-PredictionViewStyle are invoked only when a runtime Get-Command capability probe confirms the parameters exist; stock Windows PowerShell 5.1 (PSReadLine 2.0) skips them safely.')]
+param()
+
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
 Set-PSReadLineOption -EditMode Windows
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,17 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-PSReadLineOption -PredictionSource/-PredictionViewStyle are invoked only when a runtime Get-Command capability probe confirms the parameters exist; stock Windows PowerShell 5.1 (PSReadLine 2.0) skips them safely.')]
+param()
+
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
 Set-PSReadLineOption -EditMode Windows
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/WindowsPowerShellFallback_Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/WindowsPowerShellFallback_Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,17 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-PSReadLineOption -PredictionSource/-PredictionViewStyle are invoked only when a runtime Get-Command capability probe confirms the parameters exist; stock Windows PowerShell 5.1 (PSReadLine 2.0) skips them safely.')]
+param()
+
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
 Set-PSReadLineOption -EditMode Windows
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/profile.ps1
+++ b/Config/Powershell/profile.ps1
@@ -1,6 +1,17 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin
-Set-PSReadLineOption -PredictionViewStyle InLineView
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-PSReadLineOption -PredictionSource/-PredictionViewStyle are invoked only when a runtime Get-Command capability probe confirms the parameters exist; stock Windows PowerShell 5.1 (PSReadLine 2.0) skips them safely.')]
+param()
+
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
 Set-PSReadLineOption -EditMode Windows
 Set-PSReadlineKeyHandler -Key Tab -Function Complete
 

--- a/Scripts/Backup.ps1
+++ b/Scripts/Backup.ps1
@@ -10,6 +10,13 @@ if (-not (Test-Path -LiteralPath $diagnosticsHelpersPath -PathType Leaf)) {
 
 . $diagnosticsHelpersPath
 
+$compatibilityHelpersPath = Join-Path -Path $scriptsDirectory -ChildPath "Utils/Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_BACKUP_COMPATIBILITY_HELPER_MISSING: compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+. $compatibilityHelpersPath
+
 function Get-LastExitCodeOrDefault {
     $lecValue = Get-Variable -Name "LASTEXITCODE" -ValueOnly -ErrorAction SilentlyContinue
     if ($null -ne $lecValue) {
@@ -295,15 +302,15 @@ function Assert-BackupStepScriptsExist {
 }
 
 function Get-CurrentPlatformName {
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         return "Windows"
     }
 
-    if ($IsMacOS) {
+    if (Test-IsMacOSPlatform) {
         return "macOS"
     }
 
-    if ($IsLinux) {
+    if (Test-IsLinuxPlatform) {
         return "Linux"
     }
 

--- a/Scripts/Config/ConfigBackup.ps1
+++ b/Scripts/Config/ConfigBackup.ps1
@@ -14,7 +14,7 @@ try {
 
     $backupFolder = Join-Path -Path (Join-Path -Path $baseDirectory -ChildPath "Config") -ChildPath ".config"
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
     else {
         $backupEntries = @(Get-ChildItem -LiteralPath $backupFolder -Force -ErrorAction Stop)

--- a/Scripts/Config/ConfigRestore.ps1
+++ b/Scripts/Config/ConfigRestore.ps1
@@ -16,7 +16,7 @@ try {
 
     if (-not (Test-Path -LiteralPath $configDir -PathType Container)) {
         Write-Host ".config directory not found, creating it at: $configDir"
-        New-Item -LiteralPath $configDir -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($configDir) | Out-Null
     }
 
     $backupItems = @(Get-ChildItem -LiteralPath $backupDir -Force -ErrorAction Stop)

--- a/Scripts/PowerToys/PowerToysBackup.ps1
+++ b/Scripts/PowerToys/PowerToysBackup.ps1
@@ -15,7 +15,7 @@ try {
     $backupFolder = Join-Path -Path $rootDirectory -ChildPath "Config"
     $backupFolder = Join-Path -Path $backupFolder -ChildPath "PowerToys"
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
     else {
         $backupEntries = @(Get-ChildItem -LiteralPath $backupFolder -Force -ErrorAction Stop)

--- a/Scripts/Powershell/PowershellBackup.ps1
+++ b/Scripts/Powershell/PowershellBackup.ps1
@@ -1,6 +1,13 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath '../Utils/Common/CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath "..") -ErrorAction Stop).Path
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $baseDirectory -ChildPath "..") -ErrorAction Stop).Path
 $backupFolder = Join-Path -Path (Join-Path -Path $baseDirectory -ChildPath "Config") -ChildPath "Powershell"
@@ -8,7 +15,7 @@ Push-Location -LiteralPath $baseDirectory
 
 try {
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
 
     $profilesBackedUp = 0
@@ -23,7 +30,7 @@ try {
             Path = $PROFILE.CurrentUserAllHosts
         })
 
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         $documentsPath = Join-Path -Path $HOME -ChildPath "Documents"
         [void]$candidateProfiles.Add([pscustomobject]@{
                 Name = "WindowsPowerShellFallback"
@@ -31,7 +38,7 @@ try {
             })
     }
 
-    $pathComparer = if ($IsWindows) {
+    $pathComparer = if (Test-IsWindowsPlatform) {
         [System.StringComparer]::OrdinalIgnoreCase
     }
     else {

--- a/Scripts/Powershell/PowershellRestore.ps1
+++ b/Scripts/Powershell/PowershellRestore.ps1
@@ -1,6 +1,13 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath '../Utils/Common/CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath "..") -ErrorAction Stop).Path
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $baseDirectory -ChildPath "..") -ErrorAction Stop).Path
 Push-Location -LiteralPath $baseDirectory
@@ -74,7 +81,7 @@ try {
         return $defaultBackup
     }
 
-    $targetPathComparer = if ($IsWindows) {
+    $targetPathComparer = if (Test-IsWindowsPlatform) {
         [System.StringComparer]::OrdinalIgnoreCase
     }
     else {
@@ -102,7 +109,7 @@ try {
             })
     }
 
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         $documentsPath = Join-Path -Path $HOME -ChildPath 'Documents'
         $windowsPowerShellLegacyPath = Join-Path -Path $documentsPath -ChildPath 'WindowsPowerShell'
         $windowsPowerShellLegacyPath = Join-Path -Path $windowsPowerShellLegacyPath -ChildPath $profileLeafName
@@ -124,7 +131,7 @@ try {
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
     $backupFolder = Join-Path -Path $HOME -ChildPath 'PowerShell_Settings_Backup'
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
 
     $profilesRestored = 0
@@ -141,7 +148,7 @@ try {
         $targetDirectory = Split-Path -Path $target.Path -Parent
         if (-not [string]::IsNullOrWhiteSpace($targetDirectory) -and -not (Test-Path -LiteralPath $targetDirectory -PathType Container)) {
             Write-Host "PowerShell profile directory not found at $targetDirectory, creating..."
-            New-Item -ItemType Directory -LiteralPath $targetDirectory -Force | Out-Null
+            [System.IO.Directory]::CreateDirectory($targetDirectory) | Out-Null
         }
 
         if (Test-Path -LiteralPath $target.Path -PathType Leaf) {

--- a/Scripts/Restore.ps1
+++ b/Scripts/Restore.ps1
@@ -4,6 +4,13 @@ $ErrorActionPreference = "Stop"
 $scriptsDirectory = (Resolve-Path -LiteralPath $PSScriptRoot -ErrorAction Stop).Path
 $pwshCommand = (Get-Command -Name "pwsh" -ErrorAction Stop).Source
 
+$compatibilityHelpersPath = Join-Path -Path $scriptsDirectory -ChildPath "Utils/Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_RESTORE_COMPATIBILITY_HELPER_MISSING: compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+. $compatibilityHelpersPath
+
 function Get-LastExitCodeOrDefault {
     $lecValue = Get-Variable -Name "LASTEXITCODE" -ValueOnly -ErrorAction SilentlyContinue
     if ($null -ne $lecValue) {
@@ -70,15 +77,15 @@ function Assert-RestoreStepScriptsExist {
 }
 
 function Get-CurrentPlatformName {
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         return "Windows"
     }
 
-    if ($IsMacOS) {
+    if (Test-IsMacOSPlatform) {
         return "macOS"
     }
 
-    if ($IsLinux) {
+    if (Test-IsLinuxPlatform) {
         return "Linux"
     }
 

--- a/Scripts/Update.ps1
+++ b/Scripts/Update.ps1
@@ -2,15 +2,15 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 function Get-CurrentPlatformName {
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         return "Windows"
     }
 
-    if ($IsMacOS) {
+    if (Test-IsMacOSPlatform) {
         return "macOS"
     }
 
-    if ($IsLinux) {
+    if (Test-IsLinuxPlatform) {
         return "Linux"
     }
 
@@ -81,6 +81,12 @@ function Assert-ApplicableUpdateStepsFlat {
 }
 
 $scriptsDirectory = (Resolve-Path -LiteralPath $PSScriptRoot -ErrorAction Stop).Path
+$compatibilityHelpersPath = Join-Path -Path $scriptsDirectory -ChildPath "Utils/Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_UPDATE_COMPATIBILITY_HELPER_MISSING: compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+. $compatibilityHelpersPath
 $steps = @(
     @{ Name = "StopKomorebi"; RelativeScriptPath = "Komorebi/StopKomorebi.ps1"; SupportedPlatforms = @("Windows") },
     @{ Name = "ScoopUpdate"; RelativeScriptPath = "Scoop/ScoopUpdate.ps1"; SupportedPlatforms = @("Windows") },

--- a/Scripts/Utils/BackupDxMessaging.ps1
+++ b/Scripts/Utils/BackupDxMessaging.ps1
@@ -9,7 +9,14 @@ if (-not (Test-Path -LiteralPath $strictModeHelpersPath -PathType Leaf)) {
 
 .$strictModeHelpersPath
 
-if (-not $IsWindows) {
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+.$compatibilityHelpersPath
+
+if (-not (Test-IsWindowsPlatform)) {
     Write-Error "E_DXMSG_BACKUP_WINDOWS_ONLY: This script requires Windows (Robocopy). Current OS is not Windows."
     exit 1
 }
@@ -51,7 +58,7 @@ Write-Verbose (
 if (-not (Test-Path -LiteralPath $backupDir -PathType Container)) {
     Write-Host "Destination directory does not exist, attempting to create: $backupDir"
     try {
-        New-Item -LiteralPath $backupDir -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupDir) | Out-Null
         Write-Host "Destination directory created successfully."
     }
     catch {
@@ -71,7 +78,7 @@ Write-Host "Starting backup process..."
 try {
     # 1. Create Temporary Staging Directory
     Write-Host "Creating temporary staging directory: $tempStagePath"
-    New-Item -LiteralPath $tempStagePath -ItemType Directory -Force | Out-Null
+    [System.IO.Directory]::CreateDirectory($tempStagePath) | Out-Null
 
     # 2. Copy Source to Staging using Robocopy (includes hidden, excludes specified)
     Write-Host "Copying files from '$sourcePath' to staging area, excluding specified items..."

--- a/Scripts/Utils/Common/CompatibilityHelpers.ps1
+++ b/Scripts/Utils/Common/CompatibilityHelpers.ps1
@@ -1,0 +1,342 @@
+# CompatibilityHelpers.ps1
+#
+# Single source of truth for Windows PowerShell 5.1 (Desktop edition / .NET Framework)
+# <-> PowerShell 7+ (Core edition / .NET 5+) portability shims.
+#
+# Why this file exists:
+#   Scripts in this repository must run on BOTH Windows PowerShell 5.1 and PowerShell 7+.
+#   Several constructs the codebase relies on behave differently or are absent on 5.1:
+#     - $IsWindows / $IsMacOS / $IsLinux automatic variables do not exist on Desktop
+#       edition; under `Set-StrictMode -Version Latest` a bare reference THROWS
+#       ("the variable cannot be retrieved because it has not been set").
+#     - [System.IO.Path]::GetRelativePath(string,string) does not exist in .NET Framework.
+#     - `ConvertTo-Json -AsArray` and `ConvertFrom-Json -Depth/-NoEnumerate` are 6+ only.
+#   Consumers must dot-source this file and call these helpers instead of using the
+#   non-portable construct directly. Re-divergence is policy-tested in
+#   Tests/Utils/CompatibilityConventions.Tests.ps1 and the shims are unit-tested in
+#   Tests/Utils/CompatibilityHelpers.Tests.ps1.
+#
+# This file must itself remain 5.1-safe: it must not reference $IsWindows/$IsMacOS/$IsLinux
+# directly, must not use 7+-only syntax (ternary, ??, &&/||), and must not call 7+-only APIs.
+
+function Test-IsDesktopEdition {
+    # Windows PowerShell 5.1 reports PSEdition 'Desktop'; PowerShell 6+ reports 'Core'.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    return ($PSVersionTable.PSEdition -eq 'Desktop')
+}
+
+function Get-PortableAutomaticBool {
+    # Reads an OS automatic variable ($IsWindows/$IsMacOS/$IsLinux) without tripping
+    # StrictMode on Desktop edition, where those variables are undefined.
+    # Get-Variable is a cmdlet probe, so SilentlyContinue avoids the strict-mode throw
+    # that a bare `$IsWindows` reference would raise.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    $variable = Get-Variable -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $variable) {
+        return $false
+    }
+
+    return [bool]$variable.Value
+}
+
+function Test-IsWindowsPlatform {
+    # Portable replacement for $IsWindows that is safe on Windows PowerShell 5.1.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    # Desktop edition (Windows PowerShell) only ever runs on Windows.
+    if (Test-IsDesktopEdition) {
+        return $true
+    }
+
+    return (Get-PortableAutomaticBool -Name 'IsWindows')
+}
+
+function Test-IsMacOSPlatform {
+    # Portable replacement for $IsMacOS that is safe on Windows PowerShell 5.1.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (Test-IsDesktopEdition) {
+        return $false
+    }
+
+    return (Get-PortableAutomaticBool -Name 'IsMacOS')
+}
+
+function Test-IsLinuxPlatform {
+    # Portable replacement for $IsLinux that is safe on Windows PowerShell 5.1.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (Test-IsDesktopEdition) {
+        return $false
+    }
+
+    return (Get-PortableAutomaticBool -Name 'IsLinux')
+}
+
+function Get-RelativePathFallback {
+    # .NET Framework fallback for [System.IO.Path]::GetRelativePath. Mirrors the native
+    # algorithm: normalize both paths, confirm a shared root, diff the path segments, and
+    # emit `..` for each base segment past the common prefix followed by the remaining
+    # target segments. Kept as a dedicated function so it can be parity-tested directly
+    # against the native method on editions where the native method exists.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string]$BasePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string]$TargetPath
+    )
+
+    $separator = [System.IO.Path]::DirectorySeparatorChar
+    $altSeparator = [System.IO.Path]::AltDirectorySeparatorChar
+    $splitChars = [char[]]@($separator, $altSeparator)
+    $trimChars = [char[]]@($separator, $altSeparator)
+
+    # GetFullPath normalizes the inputs the same way the native method does.
+    $baseFull = [System.IO.Path]::GetFullPath($BasePath)
+    $targetFull = [System.IO.Path]::GetFullPath($TargetPath)
+
+    # Windows path comparison is case-insensitive; Unix is case-sensitive. The fallback
+    # only runs on Desktop edition (Windows) in production, but matching the running
+    # platform keeps parity tests meaningful on Linux/macOS too.
+    if (Test-IsWindowsPlatform) {
+        $comparison = [System.StringComparison]::OrdinalIgnoreCase
+    } else {
+        $comparison = [System.StringComparison]::Ordinal
+    }
+
+    # A relative path only exists when both paths share the same root (drive/UNC/`/`).
+    # When roots differ the native method returns the normalized full target path.
+    $baseRoot = [System.IO.Path]::GetPathRoot($baseFull)
+    $targetRoot = [System.IO.Path]::GetPathRoot($targetFull)
+    if (-not [string]::Equals($baseRoot, $targetRoot, $comparison)) {
+        return $targetFull
+    }
+
+    $baseTrimmed = $baseFull.TrimEnd($trimChars)
+    $targetTrimmed = $targetFull.TrimEnd($trimChars)
+    if ([string]::Equals($baseTrimmed, $targetTrimmed, $comparison)) {
+        # Identical paths: native GetRelativePath returns ".".
+        return '.'
+    }
+
+    # Slice off the shared root before diffing segments. Trimming a root-only path
+    # (for example "/" or "C:\") can leave a string shorter than the root, so guard
+    # the substring to avoid an out-of-range start index.
+    $rootLength = $baseRoot.Length
+    if ($baseTrimmed.Length -gt $rootLength) {
+        $baseAfterRoot = $baseTrimmed.Substring($rootLength)
+    } else {
+        $baseAfterRoot = ''
+    }
+    if ($targetTrimmed.Length -gt $rootLength) {
+        $targetAfterRoot = $targetTrimmed.Substring($rootLength)
+    } else {
+        $targetAfterRoot = ''
+    }
+
+    $baseSegments = $baseAfterRoot.Split($splitChars, [System.StringSplitOptions]::RemoveEmptyEntries)
+    $targetSegments = $targetAfterRoot.Split($splitChars, [System.StringSplitOptions]::RemoveEmptyEntries)
+
+    $common = 0
+    $maxCommon = [Math]::Min($baseSegments.Length, $targetSegments.Length)
+    while ($common -lt $maxCommon -and [string]::Equals($baseSegments[$common], $targetSegments[$common], $comparison)) {
+        $common++
+    }
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    for ($i = $common; $i -lt $baseSegments.Length; $i++) {
+        $parts.Add('..')
+    }
+    for ($i = $common; $i -lt $targetSegments.Length; $i++) {
+        $parts.Add($targetSegments[$i])
+    }
+
+    if ($parts.Count -eq 0) {
+        return '.'
+    }
+
+    return [string]::Join([string]$separator, $parts.ToArray())
+}
+
+function Get-RelativePathCompat {
+    # Portable replacement for [System.IO.Path]::GetRelativePath(BasePath, TargetPath).
+    # Uses the native method on editions that have it (.NET Core / .NET 5+) and a
+    # segment-diff fallback on .NET Framework (Windows PowerShell 5.1).
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '',
+        Justification = 'GetRelativePath is reached only after a runtime reflection guard confirms the native overload exists; Windows PowerShell 5.1 always takes the Get-RelativePathFallback branch. This shim is the single sanctioned reference to the native method.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string]$BasePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [string]$TargetPath,
+
+        # Test-only: force the .NET Framework fallback even where the native method exists.
+        [Parameter(Mandatory = $false)]
+        [switch]$ForceFallback
+    )
+
+    if (-not $ForceFallback) {
+        $nativeMethod = [System.IO.Path].GetMethod('GetRelativePath', [type[]]@([string], [string]))
+        if ($null -ne $nativeMethod) {
+            return [System.IO.Path]::GetRelativePath($BasePath, $TargetPath)
+        }
+    }
+
+    return (Get-RelativePathFallback -BasePath $BasePath -TargetPath $TargetPath)
+}
+
+function ConvertTo-JsonArrayCompat {
+    # Portable replacement for `... | ConvertTo-Json -AsArray`.
+    # On Windows PowerShell 5.1 `-AsArray` does not exist, and ConvertTo-Json collapses
+    # single-element collections to a bare value. This shim uses -AsArray when present
+    # (6+) and reconstructs array shape manually on 5.1.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '',
+        Justification = 'ConvertTo-Json -AsArray is reached only after a runtime Get-Command capability probe confirms the parameter exists; Windows PowerShell 5.1 takes the manual array-shape branch instead. This shim is the single sanctioned use of -AsArray.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $InputObject,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 100)]
+        [int]$Depth = 10,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Compress
+    )
+
+    begin {
+        $items = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+        # Collect pipeline input element-by-element so callers can pipe a collection.
+        foreach ($item in $InputObject) {
+            $items.Add($item)
+        }
+    }
+
+    end {
+        $materialized = @($items)
+
+        # Empty collections are an array on every edition.
+        if ($materialized.Count -eq 0) {
+            return '[]'
+        }
+
+        # PowerShell 6+ has -AsArray. Pipe the elements so each is a separate item and
+        # -AsArray guarantees array shape (including the single-element case).
+        $supportsAsArray = (Get-Command -Name 'ConvertTo-Json' -ErrorAction Stop).Parameters.ContainsKey('AsArray')
+        if ($supportsAsArray) {
+            if ($Compress) {
+                return ($materialized | ConvertTo-Json -Depth $Depth -AsArray -Compress)
+            }
+            return ($materialized | ConvertTo-Json -Depth $Depth -AsArray)
+        }
+
+        # Windows PowerShell 5.1 has no -AsArray and collapses single-element collections to
+        # a bare value. Serialize via -InputObject (avoids pipeline unrolling) and wrap when
+        # the serializer did not already emit array brackets.
+        $jsonParameters = @{ InputObject = $materialized; Depth = $Depth }
+        if ($Compress) {
+            $jsonParameters['Compress'] = $true
+        }
+
+        $json = ConvertTo-Json @jsonParameters
+        if ($json.TrimStart().StartsWith('[')) {
+            return $json
+        }
+
+        if ($Compress) {
+            return ('[' + $json + ']')
+        }
+
+        $newLine = [System.Environment]::NewLine
+        $indented = (($json -split "`r?`n") | ForEach-Object { '  ' + $_ }) -join $newLine
+        return ('[' + $newLine + $indented + $newLine + ']')
+    }
+}
+
+# direct-json-ok: ConvertFrom-Json - this helper IS the sanctioned cross-version
+# ConvertFrom-Json wrapper; it must call the cmdlet directly to provide the portable
+# alternative that other utility scripts use in its place.
+function ConvertFrom-JsonCompat {
+    # Portable replacement for ConvertFrom-Json that tolerates the absence of
+    # -Depth and -NoEnumerate on Windows PowerShell 5.1.
+    #   - On 5.1, -Depth is unsupported (its parser has a fixed effective depth) and is
+    #     silently dropped.
+    #   - On 5.1, -NoEnumerate is unsupported; array preservation is reproduced by
+    #     returning the parsed value wrapped with the comma operator so a top-level
+    #     array is not unrolled by the caller's pipeline.
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        $InputObject,
+
+        [Parameter(Mandatory = $false)]
+        [int]$Depth,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$NoEnumerate
+    )
+
+    process {
+        $convertCommand = Get-Command -Name 'ConvertFrom-Json' -ErrorAction Stop
+        $convertParameters = @{ ErrorAction = 'Stop' }
+
+        if ($PSBoundParameters.ContainsKey('Depth') -and $convertCommand.Parameters.ContainsKey('Depth')) {
+            $convertParameters['Depth'] = $Depth
+        }
+
+        # Use native -NoEnumerate when present so nested structures parse correctly; the
+        # comma-operator return below still applies (see note).
+        if ($NoEnumerate -and $convertCommand.Parameters.ContainsKey('NoEnumerate')) {
+            $convertParameters['NoEnumerate'] = $true
+        }
+
+        $parsed = $InputObject | ConvertFrom-Json @convertParameters
+
+        if ($NoEnumerate -and ([string]$InputObject).TrimStart().StartsWith('[')) {
+            # A top-level JSON array must be returned as a SINGLE object so that neither
+            # this function's own pipeline output (which would otherwise unroll it) nor
+            # Windows PowerShell 5.1's enumeration collapses it — in particular a
+            # single-element array must not degrade to a scalar. Materialize and emit via
+            # the comma operator. Non-array JSON (object/scalar) is returned as-is.
+            return , ([object[]]@($parsed))
+        }
+
+        return $parsed
+    }
+}

--- a/Scripts/Utils/Common/CompatibilityHelpers.ps1
+++ b/Scripts/Utils/Common/CompatibilityHelpers.ps1
@@ -340,3 +340,316 @@ function ConvertFrom-JsonCompat {
         return $parsed
     }
 }
+
+function ConvertTo-ProcessArgumentString {
+    # Builds a single Win32 command-line string from an argument vector, applying the exact
+    # escaping algorithm .NET Core uses internally to render ProcessStartInfo.ArgumentList
+    # into the OS command line (the runtime's PasteArguments.AppendArgument). This is the
+    # .NET Framework (Windows PowerShell 5.1) fallback for the ArgumentList collection, which
+    # does not exist before .NET Core 2.1; see Set-PortableProcessArguments.
+    #
+    # Rules (CommandLineToArgvW-compatible):
+    #   - Empty arguments render as "" so they survive as a distinct, empty token.
+    #   - Arguments without whitespace or a double quote are emitted verbatim (backslashes
+    #     stay literal because they are not adjacent to a quote).
+    #   - Otherwise the argument is wrapped in quotes; backslashes are doubled only when they
+    #     precede a quote (or the closing quote) and an embedded quote is escaped as \".
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]]$ArgumentList = @()
+    )
+
+    if ($null -eq $ArgumentList) {
+        return ""
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    $backslash = [char]'\'
+    $quote = [char]'"'
+
+    foreach ($rawArgument in @($ArgumentList)) {
+        $argument = if ($null -eq $rawArgument) { '' } else { [string]$rawArgument }
+
+        if ($builder.Length -gt 0) {
+            [void]$builder.Append(' ')
+        }
+
+        $needsQuoting = ($argument.Length -eq 0)
+        if (-not $needsQuoting) {
+            foreach ($character in $argument.ToCharArray()) {
+                if ([char]::IsWhiteSpace($character) -or $character -eq $quote) {
+                    $needsQuoting = $true
+                    break
+                }
+            }
+        }
+
+        if (-not $needsQuoting) {
+            [void]$builder.Append($argument)
+            continue
+        }
+
+        [void]$builder.Append($quote)
+        $index = 0
+        while ($index -lt $argument.Length) {
+            $character = $argument[$index]
+            $index++
+
+            if ($character -eq $backslash) {
+                $backslashCount = 1
+                while ($index -lt $argument.Length -and $argument[$index] -eq $backslash) {
+                    $index++
+                    $backslashCount++
+                }
+
+                if ($index -eq $argument.Length) {
+                    # Trailing run of backslashes precedes the closing quote: double them so
+                    # the quote is not consumed as an escape.
+                    [void]$builder.Append($backslash, $backslashCount * 2)
+                }
+                elseif ($argument[$index] -eq $quote) {
+                    # Backslashes precede a literal quote: double them and escape the quote.
+                    [void]$builder.Append($backslash, $backslashCount * 2 + 1)
+                    [void]$builder.Append($quote)
+                    $index++
+                }
+                else {
+                    # Backslashes are not adjacent to a quote: emit them unchanged.
+                    [void]$builder.Append($backslash, $backslashCount)
+                }
+            }
+            elseif ($character -eq $quote) {
+                [void]$builder.Append($backslash)
+                [void]$builder.Append($quote)
+            }
+            else {
+                [void]$builder.Append($character)
+            }
+        }
+        [void]$builder.Append($quote)
+    }
+
+    return $builder.ToString()
+}
+
+function Set-PortableProcessArguments {
+    # Portable replacement for the `foreach ($a in $args) { $psi.ArgumentList.Add($a) }`
+    # idiom. ProcessStartInfo.ArgumentList (which escapes each argument independently and
+    # avoids hand-rolled command-line quoting bugs) exists only on .NET Core 2.1+/.NET 5+
+    # (PowerShell 7+). On .NET Framework (Windows PowerShell 5.1) the property is absent and
+    # accessing it throws "The property 'ArgumentList' cannot be found on this object"; there
+    # the equivalent escaped string is assigned to .Arguments instead. This is the single
+    # sanctioned reference to ProcessStartInfo.ArgumentList in the repository.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '',
+        Justification = 'ArgumentList is populated only after a runtime reflection guard confirms the .NET Core property exists; Windows PowerShell 5.1 takes the ConvertTo-ProcessArgumentString / .Arguments branch. Single sanctioned reference to ProcessStartInfo.ArgumentList.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Diagnostics.ProcessStartInfo]$StartInfo,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]]$ArgumentList = @(),
+
+        # Test-only: force the .NET Framework (.Arguments string) fallback even where the
+        # native ArgumentList collection exists.
+        [Parameter(Mandatory = $false)]
+        [switch]$ForceFallback
+    )
+
+    $normalizedArguments = @()
+    if ($null -ne $ArgumentList) {
+        $normalizedArguments = @($ArgumentList)
+    }
+
+    $hasArgumentList = $false
+    if (-not $ForceFallback) {
+        $hasArgumentList = ($null -ne [System.Diagnostics.ProcessStartInfo].GetProperty('ArgumentList'))
+    }
+
+    if ($hasArgumentList) {
+        foreach ($argument in $normalizedArguments) {
+            [void]$StartInfo.ArgumentList.Add($argument) # compat-core-member-ok: guarded by the reflection probe above.
+        }
+        return
+    }
+
+    # Advisory telemetry only (argument count, never values, to avoid leaking secrets into
+    # verbose logs): records that the .NET Framework escaping path was taken on this edition.
+    Write-Verbose ("Set-PortableProcessArguments diagnostics: mode=arguments-string-fallback argumentCount={0} (ProcessStartInfo.ArgumentList is unavailable on this PowerShell edition)." -f $normalizedArguments.Count)
+    $StartInfo.Arguments = ConvertTo-ProcessArgumentString -ArgumentList $normalizedArguments
+}
+
+function Stop-ProcessTreePortably {
+    # Portable replacement for [System.Diagnostics.Process]::Kill($true) (terminate the whole
+    # process tree). The Kill(bool) overload was added in .NET Core 3.0 and is ABSENT on
+    # Windows PowerShell 5.1 (.NET Framework), where $process.Kill($true) throws "Cannot find an
+    # overload for 'Kill' and the argument count: '1'". On editions with the overload the entire
+    # tree is terminated; on 5.1 the parameterless Kill() terminates the target process (best
+    # effort — accepting that orphaned children may linger is better than throwing during
+    # timeout cleanup). This is the single sanctioned reference to the Kill(bool) overload.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '',
+        Justification = 'Kill($true) is invoked only after a runtime reflection guard confirms the .NET Core 3.0+ overload exists; Windows PowerShell 5.1 falls back to the parameterless Kill(). Single sanctioned reference to the Kill(bool) overload.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Diagnostics.Process]$Process,
+
+        # Test-only: force the Windows PowerShell 5.1 (parameterless Kill) fallback even where
+        # the Kill(bool) overload exists.
+        [Parameter(Mandatory = $false)]
+        [switch]$ForceFallback
+    )
+
+    $hasTreeKill = $false
+    if (-not $ForceFallback) {
+        $hasTreeKill = ($null -ne [System.Diagnostics.Process].GetMethod('Kill', [type[]]@([bool])))
+    }
+
+    if ($hasTreeKill) {
+        $Process.Kill($true) # compat-core-member-ok: guarded by the reflection probe above.
+        return
+    }
+
+    $Process.Kill()
+}
+
+function Get-FileSystemLinkTargetProperty {
+    # Reads the immediate symbolic-link/reparse-point target of a FileSystemInfo-like object
+    # from the LinkTarget/Target members, returning the target string or $null. Both the
+    # .NET 6 LinkTarget property and the Windows PowerShell 5.0+ Target ETS member are
+    # consulted via duck typing so the same helper works on real items across editions and on
+    # the Add-Member test doubles used by the discovery tests. On Windows PowerShell 5.1 the
+    # Target member can surface as a string array (legacy multi-target shape); the first
+    # entry is used.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        $Item
+    )
+
+    foreach ($propertyName in @('LinkTarget', 'Target')) {
+        $property = $Item.PSObject.Properties[$propertyName]
+        if ($null -eq $property -or $null -eq $property.Value) {
+            continue
+        }
+
+        $value = $property.Value
+        if ($value -is [System.Array]) {
+            if ($value.Length -eq 0) {
+                continue
+            }
+            $value = $value[0]
+        }
+
+        $stringValue = [string]$value
+        if (-not [string]::IsNullOrWhiteSpace($stringValue)) {
+            return $stringValue
+        }
+    }
+
+    return $null
+}
+
+function Get-PortableLinkTarget {
+    # Portable equivalent of [System.IO.FileSystemInfo]::ResolveLinkTarget($true), which was
+    # introduced in .NET 6 / PowerShell 7.1 and is absent on Windows PowerShell 5.1. Returns
+    # the FINAL target's full path (string) for a symbolic link or reparse point, or $null
+    # when the item is not a link or no target can be resolved.
+    #
+    # On editions that expose the native method it is used directly (it already follows link
+    # chains to the final target). On Windows PowerShell 5.1 the link target is read from the
+    # LinkTarget/Target ETS members that PowerShell projects onto FileSystemInfo and chains
+    # are followed hop-by-hop (bounded by -MaxDepth, and stopping as soon as a hop no longer
+    # resolves or is no longer a link) so the result matches the native "final target"
+    # semantics. Item access is duck-typed so production callers and the Add-Member test
+    # doubles share one code path. This is the single sanctioned reference to ResolveLinkTarget.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '',
+        Justification = 'ResolveLinkTarget is invoked only after a runtime duck-typing guard confirms the .NET 6+ method is present on the instance; Windows PowerShell 5.1 takes the LinkTarget/Target ETS branch. Single sanctioned reference to the native method.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        $Item,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 256)]
+        [int]$MaxDepth = 64,
+
+        # Test-only: force the Windows PowerShell 5.1 (LinkTarget/Target ETS) fallback even
+        # where the native ResolveLinkTarget method exists, so the fallback can be parity-
+        # tested against the native method on PowerShell 7+.
+        [Parameter(Mandatory = $false)]
+        [switch]$ForceFallback
+    )
+
+    if (-not $ForceFallback -and ($Item.PSObject.Methods.Name -contains 'ResolveLinkTarget')) {
+        $resolved = $null
+        try {
+            $resolved = $Item.ResolveLinkTarget($true) # compat-core-member-ok: guarded by the PSObject.Methods probe above.
+        }
+        catch {
+            $resolved = $null
+        }
+
+        if ($null -ne $resolved -and -not [string]::IsNullOrWhiteSpace([string]$resolved.FullName)) {
+            return [string]$resolved.FullName
+        }
+
+        return $null
+    }
+
+    $currentItem = $Item
+    $resolvedPath = $null
+    # Track visited targets so a symlink cycle terminates (bounded additionally by -MaxDepth)
+    # instead of looping; comparison is OS-appropriate (case-insensitive only on Windows).
+    $visitedComparer = if (Test-IsWindowsPlatform) { [System.StringComparer]::OrdinalIgnoreCase } else { [System.StringComparer]::Ordinal }
+    $visitedTargets = [System.Collections.Generic.HashSet[string]]::new($visitedComparer)
+    for ($depth = 0; $depth -lt $MaxDepth; $depth++) {
+        $hopTarget = Get-FileSystemLinkTargetProperty -Item $currentItem
+        if ([string]::IsNullOrWhiteSpace($hopTarget)) {
+            break
+        }
+
+        if (-not [System.IO.Path]::IsPathRooted($hopTarget)) {
+            # A relative target is resolved against the directory containing the link.
+            $linkParent = Split-Path -Path ([string]$currentItem.FullName) -Parent
+            if ([string]::IsNullOrWhiteSpace($linkParent)) {
+                $linkParent = [System.IO.Path]::GetPathRoot([string]$currentItem.FullName)
+            }
+            $hopTarget = Join-Path -Path $linkParent -ChildPath $hopTarget
+        }
+
+        $resolvedPath = [System.IO.Path]::GetFullPath($hopTarget)
+
+        if (-not $visitedTargets.Add($resolvedPath)) {
+            # Cycle detected (this target was already resolved on a previous hop). The native
+            # ResolveLinkTarget($true) throws "Too many levels of symbolic links" on a cycle,
+            # which callers treat as unresolved; return $null here for the same final outcome.
+            return $null
+        }
+
+        if (-not (Test-Path -LiteralPath $resolvedPath)) {
+            break
+        }
+
+        $nextItem = Get-Item -LiteralPath $resolvedPath -Force -ErrorAction SilentlyContinue
+        if ($null -eq $nextItem -or [string]::IsNullOrWhiteSpace((Get-FileSystemLinkTargetProperty -Item $nextItem))) {
+            break
+        }
+
+        $currentItem = $nextItem
+    }
+
+    return $resolvedPath
+}

--- a/Scripts/Utils/Common/FormatOperatorSafetyHelpers.ps1
+++ b/Scripts/Utils/Common/FormatOperatorSafetyHelpers.ps1
@@ -1,3 +1,10 @@
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath 'CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 function Get-FormatStringPlaceholderMaxIndex {
     param(
         [Parameter(Mandatory = $false)]
@@ -115,7 +122,7 @@ function Get-FormatOperatorContinuationViolations {
             $parseErrors = $null
             $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptFile.FullName, [ref]$tokens, [ref]$parseErrors)
             if ($null -ne $parseErrors -and @($parseErrors).Count -gt 0) {
-                $relativeParsePath = ConvertTo-PortableFormatOperatorPath -PathValue ([System.IO.Path]::GetRelativePath($resolvedRootPath, $scriptFile.FullName))
+                $relativeParsePath = ConvertTo-PortableFormatOperatorPath -PathValue (Get-RelativePathCompat -BasePath $resolvedRootPath -TargetPath $scriptFile.FullName)
                 $firstParseError = [string]$parseErrors[0]
                 Write-Verbose (
                     "Format-operator safety parse diagnostics: file='{0}'; parseErrorCount={1}; firstError='{2}'" -f
@@ -172,7 +179,7 @@ function Get-FormatOperatorContinuationViolations {
 
                 $rightExpressionLine = $scriptLines[$continuationLineIndex]
 
-                $relativePath = ConvertTo-PortableFormatOperatorPath -PathValue ([System.IO.Path]::GetRelativePath($resolvedRootPath, $scriptFile.FullName))
+                $relativePath = ConvertTo-PortableFormatOperatorPath -PathValue (Get-RelativePathCompat -BasePath $resolvedRootPath -TargetPath $scriptFile.FullName)
                 $violationList.Add([pscustomobject]@{
                         Path                = $relativePath
                         Line                = $rightExpressionStartLine

--- a/Scripts/Utils/Common/ModuleHelpers.ps1
+++ b/Scripts/Utils/Common/ModuleHelpers.ps1
@@ -1,3 +1,10 @@
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath 'CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 function Add-ModulePathCandidate {
     param(
         [Parameter(Mandatory = $true)]
@@ -59,7 +66,7 @@ function Ensure-PortableUserModulePaths {
         Write-Verbose "Module path discovery: UserProfile path unavailable."
     }
 
-    if (-not $IsWindows) {
+    if (-not (Test-IsWindowsPlatform)) {
         Add-ModulePathCandidate -Path "/usr/local/share/powershell/Modules"
     }
 
@@ -70,9 +77,9 @@ function Ensure-PortableUserModulePaths {
         $entryCount,
         -not [string]::IsNullOrWhiteSpace($myDocuments),
         -not [string]::IsNullOrWhiteSpace($userHome),
-        $IsWindows,
-        $IsMacOS,
-        $IsLinux
+        (Test-IsWindowsPlatform),
+        (Test-IsMacOSPlatform),
+        (Test-IsLinuxPlatform)
     )
 }
 

--- a/Scripts/Utils/Common/QualityToolingHelpers.ps1
+++ b/Scripts/Utils/Common/QualityToolingHelpers.ps1
@@ -317,9 +317,10 @@ function Invoke-QualityToolingCapturedProcess {
     $processStartInfo.RedirectStandardOutput = $true
     $processStartInfo.RedirectStandardError = $true
 
-    foreach ($argument in @($ArgumentList)) {
-        [void]$processStartInfo.ArgumentList.Add($argument)
-    }
+    # ProcessStartInfo.ArgumentList is .NET Core-only; Set-PortableProcessArguments populates
+    # it on PowerShell 7+ and falls back to an equivalently escaped .Arguments string on
+    # Windows PowerShell 5.1 (.NET Framework), where ArgumentList does not exist.
+    Set-PortableProcessArguments -StartInfo $processStartInfo -ArgumentList $ArgumentList
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $processStartInfo
@@ -331,7 +332,7 @@ function Invoke-QualityToolingCapturedProcess {
         $exited = $process.WaitForExit($TimeoutSeconds * 1000)
         if (-not $exited) {
             try {
-                $process.Kill($true)
+                Stop-ProcessTreePortably -Process $process
             }
             catch {
                 Write-Verbose "Failed to kill timed-out process '$FilePath': $($_.Exception.Message)"
@@ -375,9 +376,8 @@ function Invoke-QualityToolingProcess {
     $processStartInfo.WorkingDirectory = $WorkingDirectory
     $processStartInfo.UseShellExecute = $false
 
-    foreach ($argument in @($ArgumentList)) {
-        [void]$processStartInfo.ArgumentList.Add($argument)
-    }
+    # ProcessStartInfo.ArgumentList is .NET Core-only; see Set-PortableProcessArguments.
+    Set-PortableProcessArguments -StartInfo $processStartInfo -ArgumentList $ArgumentList
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $processStartInfo
@@ -387,7 +387,7 @@ function Invoke-QualityToolingProcess {
         $exited = $process.WaitForExit($TimeoutSeconds * 1000)
         if (-not $exited) {
             try {
-                $process.Kill($true)
+                Stop-ProcessTreePortably -Process $process
             }
             catch {
                 Write-Verbose "Failed to kill timed-out process '$FilePath': $($_.Exception.Message)"

--- a/Scripts/Utils/Common/QualityToolingHelpers.ps1
+++ b/Scripts/Utils/Common/QualityToolingHelpers.ps1
@@ -9,6 +9,13 @@
 # stable diagnostic codes derived from $Context.DiagnosticPrefix and
 # $Context.TargetDiagnosticPrefix so the consuming scripts keep verbatim error strings.
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath 'CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 function New-QualityToolingContext {
     [CmdletBinding()]
     param(
@@ -100,15 +107,15 @@ function Get-QualityToolingOperatingSystemName {
         [pscustomobject]$Context
     )
 
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         return "windows"
     }
 
-    if ($IsMacOS) {
+    if (Test-IsMacOSPlatform) {
         return "darwin"
     }
 
-    if ($IsLinux) {
+    if (Test-IsLinuxPlatform) {
         return "linux"
     }
 
@@ -712,7 +719,7 @@ function Set-QualityToolingExecutableMode {
         [string]$ExecutablePath
     )
 
-    if ($IsWindows) {
+    if (Test-IsWindowsPlatform) {
         return
     }
 
@@ -774,7 +781,9 @@ function Invoke-QualityToolingDownload {
         for ($attempt = 1; $attempt -le 3; $attempt++) {
             try {
                 Write-Host "$($Context.LogPrefix) Downloading $($AssetSpec.ToolName) $($AssetSpec.Version) from $($AssetSpec.DownloadUrl)"
-                Invoke-WebRequest -Uri $AssetSpec.DownloadUrl -OutFile $DownloadPath -TimeoutSec $Context.DownloadTimeoutSeconds -ErrorAction Stop
+                # -UseBasicParsing avoids the Internet Explorer engine dependency on
+                # Windows PowerShell 5.1 (no-op on PowerShell 7+).
+                Invoke-WebRequest -Uri $AssetSpec.DownloadUrl -OutFile $DownloadPath -TimeoutSec $Context.DownloadTimeoutSeconds -UseBasicParsing -ErrorAction Stop
                 return
             }
             catch {
@@ -907,6 +916,7 @@ function Invoke-QualityToolingInstallLock {
 }
 
 function Resolve-QualityToolingToolExecutable {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '', Justification = 'RuntimeInformation.ProcessArchitecture is available on .NET Framework 4.7.1+, the floor on all supported Windows PowerShell 5.1 hosts.')]
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Context,
@@ -972,7 +982,7 @@ function Resolve-QualityToolingTargetFiles {
     $targets = New-Object 'System.Collections.Generic.List[string]'
     $repositoryRootFullPath = [System.IO.Path]::GetFullPath($RepositoryRoot)
     $repositoryRootWithSeparator = $repositoryRootFullPath.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
-    $pathComparison = if ($IsWindows) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+    $pathComparison = if (Test-IsWindowsPlatform) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
 
     foreach ($inputFile in @($InputFiles)) {
         if ([string]::IsNullOrWhiteSpace($inputFile)) {
@@ -1011,5 +1021,5 @@ function ConvertTo-QualityToolingRelativePath {
         [string]$Path
     )
 
-    return ([System.IO.Path]::GetRelativePath($RepositoryRoot, $Path) -replace '[\\/]+', '/')
+    return ((Get-RelativePathCompat -BasePath $RepositoryRoot -TargetPath $Path) -replace '[\\/]+', '/')
 }

--- a/Scripts/Utils/Common/StrictModeHelpers.ps1
+++ b/Scripts/Utils/Common/StrictModeHelpers.ps1
@@ -1,3 +1,10 @@
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath 'CompatibilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 function Get-SafeCount {
     [CmdletBinding()]
     param(
@@ -98,7 +105,7 @@ function ConvertFrom-JsonSingleObject {
     }
 
     try {
-        $parsed = $Json | ConvertFrom-Json -NoEnumerate -ErrorAction Stop
+        $parsed = $Json | ConvertFrom-JsonCompat -NoEnumerate -ErrorAction Stop
     } catch {
         throw "E_MALFORMED_RESPONSE: $Context could not be parsed as JSON. Preview: $safePreview"
     }

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -85,7 +85,6 @@ param(
     [string]$Repo,
 
     [Parameter(Mandatory = $false)]
-    [ArgumentCompletions("github.com")]
     [string]$GitHubHost = "github.com",
 
     [Parameter(Mandatory = $false)]
@@ -98,7 +97,6 @@ param(
     [string]$Token,
 
     [Parameter(Mandatory = $false)]
-    [ArgumentCompletions("text", "json")]
     [ValidateSet("text", "json")]
     [string]$OutputFormat = "text",
 
@@ -154,6 +152,13 @@ if (-not (Test-Path -Path $strictModeHelpersPath -PathType Leaf)) {
 }
 
 .$strictModeHelpersPath
+
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+.$compatibilityHelpersPath
 
 function Redact-SensitiveText {
     [CmdletBinding()]
@@ -1357,6 +1362,7 @@ function Get-ClipboardCommandPriority {
 
 function Copy-ToClipboard {
     [OutputType([bool])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-Clipboard -AsOSC52 is invoked only after a runtime Parameters.Keys check confirms the parameter exists (Get-ClipboardCommandPriority); Windows PowerShell 5.1 falls back to plain Set-Clipboard / pbcopy / xclip / xsel / wl-copy.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -1822,7 +1828,9 @@ function Validate-GitHubTokenForRepoAccess {
         }
 
         try {
-            $response = Invoke-WebRequest -Method GET -Uri $uri -Headers $Headers -TimeoutSec $effectiveRequestTimeoutSeconds
+            # -UseBasicParsing avoids the Internet Explorer engine dependency on Windows
+            # PowerShell 5.1 (no-op on PowerShell 7+).
+            $response = Invoke-WebRequest -Method GET -Uri $uri -Headers $Headers -TimeoutSec $effectiveRequestTimeoutSeconds -UseBasicParsing
             $repoMetadata = $null
             if (-not [string]::IsNullOrWhiteSpace($response.Content)) {
                 $repoMetadata = ConvertFrom-JsonSingleObject -Json $response.Content -Context "Repository metadata response"
@@ -2170,7 +2178,7 @@ function Format-UnresolvedThreadsAsJson {
         [object[]]$Records
     )
 
-    return ($Records | ConvertTo-Json -Depth 8 -AsArray)
+    return (ConvertTo-JsonArrayCompat -InputObject $Records -Depth 8)
 }
 
 function Assert-GraphQLVariableMap {

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -1360,9 +1360,35 @@ function Get-ClipboardCommandPriority {
     return $deduplicated.ToArray()
 }
 
+function Set-ClipboardValue {
+    # Thin, mockable seam over Set-Clipboard. Tests mock THIS command — whose parameter set is
+    # identical across every PowerShell edition — instead of Set-Clipboard directly. Pester
+    # builds a mock's parameter metadata from the real command, and Set-Clipboard's -AsOSC52
+    # switch exists only on PowerShell 7.4+, so mocking Set-Clipboard with -AsOSC52 fails
+    # parameter binding under Windows PowerShell 5.1 ("A parameter cannot be found that matches
+    # parameter name 'AsOSC52'"). The -AsOSC52 branch here is reached only after a runtime
+    # capability check (Get-ClipboardCommandPriority) confirms the parameter exists.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-Clipboard -AsOSC52 is invoked only after Get-ClipboardCommandPriority confirms the parameter exists via a runtime Parameters.Keys check; Windows PowerShell 5.1 never selects the OSC52 strategy and falls back to plain Set-Clipboard / pbcopy / xclip / xsel / wl-copy.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Value,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$AsOSC52
+    )
+
+    if ($AsOSC52) {
+        Set-Clipboard -Value $Value -AsOSC52
+    }
+    else {
+        Set-Clipboard -Value $Value
+    }
+}
+
 function Copy-ToClipboard {
     [OutputType([bool])]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-Clipboard -AsOSC52 is invoked only after a runtime Parameters.Keys check confirms the parameter exists (Get-ClipboardCommandPriority); Windows PowerShell 5.1 falls back to plain Set-Clipboard / pbcopy / xclip / xsel / wl-copy.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -1386,11 +1412,11 @@ function Copy-ToClipboard {
         try {
             switch ($clipboardCommand) {
                 "Set-Clipboard-AsOSC52" {
-                    Set-Clipboard -Value $valueToCopy -AsOSC52
+                    Set-ClipboardValue -Value $valueToCopy -AsOSC52
                     return $true
                 }
                 "Set-Clipboard" {
-                    Set-Clipboard -Value $valueToCopy
+                    Set-ClipboardValue -Value $valueToCopy
                     return $true
                 }
                 "pbcopy" {

--- a/Scripts/Utils/PandocConvertDirectory.ps1
+++ b/Scripts/Utils/PandocConvertDirectory.ps1
@@ -67,7 +67,7 @@ if (-not (Get-Command pandoc -ErrorAction SilentlyContinue)) {
 # Create Output Directory if it doesn't exist
 if (-not (Test-Path -LiteralPath $OutputDir -PathType Container)) {
     try {
-        New-Item -LiteralPath $OutputDir -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($OutputDir) | Out-Null
         Write-Host "Created output directory: $OutputDir" -ForegroundColor Cyan
     }
     catch {
@@ -106,7 +106,7 @@ foreach ($file in $htmlFiles) {
     $destinationDir = Split-Path -Path $destinationFile -Parent
     if (-not (Test-Path -LiteralPath $destinationDir -PathType Container)) {
         try {
-            New-Item -LiteralPath $destinationDir -ItemType Directory -Force | Out-Null
+            [System.IO.Directory]::CreateDirectory($destinationDir) | Out-Null
             Write-Host "Created directory: $destinationDir" -ForegroundColor Cyan
         }
         catch {

--- a/Scripts/Utils/Quality/Format-PowerShellFiles.ps1
+++ b/Scripts/Utils/Quality/Format-PowerShellFiles.ps1
@@ -14,6 +14,13 @@ if (-not (Test-Path -Path $moduleHelpersPath -PathType Leaf)) {
 
 .$moduleHelpersPath
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+.$compatibilityHelpersPath
+
 $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 
 function Get-LeadingTabIndentedLineNumbers {
@@ -98,7 +105,7 @@ foreach ($inputPath in @($Paths)) {
         continue
     }
 
-    $relativePath = [System.IO.Path]::GetRelativePath($repoRoot,$candidatePath)
+    $relativePath = Get-RelativePathCompat -BasePath $repoRoot -TargetPath $candidatePath
 
     $rawContent = [System.IO.File]::ReadAllText($candidatePath)
     [int[]]$leadingTabLinesBefore = Get-LeadingTabIndentedLineNumbers -Content $rawContent

--- a/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
@@ -302,6 +302,132 @@ function Get-WebRequestParsingViolation {
     return , @($violations.ToArray())
 }
 
+function Get-CoreOnlyMemberViolation {
+    # Flags member access to .NET members that exist only on .NET Core / .NET 5+ (PowerShell
+    # 7+) and are ABSENT on Windows PowerShell 5.1 (.NET Framework), where the access throws
+    # "The property '<name>' cannot be found on this object" at runtime. PSScriptAnalyzer's
+    # PSUseCompatibleTypes models incompatible TYPES, not incompatible MEMBERS of a type that
+    # exists on both editions, so this class is analyzer-invisible (it slipped past the gate
+    # and only surfaced in the Windows PowerShell 5.1 runtime lane). It is checked here via the
+    # AST. Each member has a tiny, explicit set of sanctioned homes: the CompatibilityHelpers
+    # shim that wraps it behind a runtime capability guard (and, for ResolveLinkTarget, the
+    # Remove-BOM discovery helper, whose raw use is itself capability-guarded).
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
+    )
+
+    $violations = New-Object System.Collections.Generic.List[object]
+
+    # Tests legitimately attach these member names to Add-Member mock doubles, and the dual-
+    # edition Pester lanes already exercise tests on Windows PowerShell 5.1 directly, so static
+    # enforcement here is scoped to production sources.
+    $normalizedFilePath = $FilePath.Replace('\', '/')
+    if ($normalizedFilePath -match '/Tests/') {
+        return , @($violations.ToArray())
+    }
+
+    # Member name -> match rules + remediation. RequireInvocation limits a method-only member
+    # to call sites; MinArgumentCount distinguishes a Core-only OVERLOAD (for example
+    # Process.Kill($true), .NET Core 3.0+) from a member present on both editions (Process.Kill()).
+    # A deliberate, runtime-guarded native access opts out with an inline '# compat-core-member-ok'
+    # marker on the access line, mirroring the repo's other inline markers (# array-unwrap-safe,
+    # # direct-json-ok). This is finer-grained and safer than whole-file allowlisting, which would
+    # also exempt a future UNguarded access in the same file.
+    $coreOnlyMembers = @{
+        'ArgumentList'      = @{ RequireInvocation = $false; MinArgumentCount = 0; Remediation = "ProcessStartInfo.ArgumentList exists only on .NET Core 2.1+ (PowerShell 7+). Use Set-PortableProcessArguments from CompatibilityHelpers.ps1." }
+        'ResolveLinkTarget' = @{ RequireInvocation = $true; MinArgumentCount = 0; Remediation = "FileSystemInfo.ResolveLinkTarget exists only on .NET 6+ (PowerShell 7.1+). Use Get-PortableLinkTarget from CompatibilityHelpers.ps1." }
+        'LinkTarget'        = @{ RequireInvocation = $false; MinArgumentCount = 0; Remediation = "FileSystemInfo.LinkTarget exists only on .NET 6+ (PowerShell 7.1+). Use Get-PortableLinkTarget / Get-FileSystemLinkTargetProperty from CompatibilityHelpers.ps1." }
+        'Kill'              = @{ RequireInvocation = $true; MinArgumentCount = 1; Remediation = "Process.Kill([bool]) exists only on .NET Core 3.0+ (PowerShell 7+). Use Stop-ProcessTreePortably from CompatibilityHelpers.ps1." }
+    }
+
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($FilePath, [ref]$tokens, [ref]$parseErrors)
+    if ($null -eq $ast) {
+        return , @($violations.ToArray())
+    }
+
+    # Read raw lines (FileShare.Read, closes immediately) to test for the opt-out marker.
+    $sourceLines = [System.IO.File]::ReadAllLines($FilePath)
+
+    $relativePath = $FilePath
+    if ($FilePath.StartsWith($RepositoryRoot)) {
+        $relativePath = $FilePath.Substring($RepositoryRoot.Length).TrimStart([char[]]@('/', '\'))
+    }
+    $relativePath = $relativePath.Replace('\', '/')
+
+    # MemberExpressionAst covers both property access ($x.ArgumentList) and method invocation
+    # ($x.ResolveLinkTarget(...)), since InvokeMemberExpressionAst derives from it. Keying on
+    # the static member NAME means $var/param references named "ArgumentList" and string
+    # arguments to reflection calls (GetProperty('ArgumentList')) are never flagged.
+    $memberAccessAsts = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.MemberExpressionAst]
+        }, $true)
+
+    foreach ($memberAst in $memberAccessAsts) {
+        $memberNameAst = $memberAst.Member
+        if (-not ($memberNameAst -is [System.Management.Automation.Language.StringConstantExpressionAst])) {
+            # Dynamic member name (for example $obj.$name); cannot be resolved statically.
+            continue
+        }
+
+        $memberName = $memberNameAst.Value
+        if (-not $coreOnlyMembers.ContainsKey($memberName)) {
+            continue
+        }
+
+        $memberSpec = $coreOnlyMembers[$memberName]
+        $isInvocation = ($memberAst -is [System.Management.Automation.Language.InvokeMemberExpressionAst])
+        if ($memberSpec.RequireInvocation -and -not $isInvocation) {
+            continue
+        }
+        if ($memberSpec.MinArgumentCount -gt 0) {
+            if (-not $isInvocation) {
+                continue
+            }
+            $argumentCount = 0
+            if ($null -ne $memberAst.Arguments) {
+                $argumentCount = @($memberAst.Arguments).Count
+            }
+            if ($argumentCount -lt $memberSpec.MinArgumentCount) {
+                continue
+            }
+        }
+
+        $lineNumber = $memberAst.Extent.StartLineNumber
+        # Scan every line the member expression spans (not just its start line) for the opt-out
+        # marker, so a marker on the visual member/closing-paren line of a multi-line expression
+        # still applies.
+        $isMarked = $false
+        for ($markerLine = $memberAst.Extent.StartLineNumber; $markerLine -le $memberAst.Extent.EndLineNumber; $markerLine++) {
+            if ($markerLine -ge 1 -and $markerLine -le $sourceLines.Length -and $sourceLines[$markerLine - 1].Contains('compat-core-member-ok')) {
+                $isMarked = $true
+                break
+            }
+        }
+        if ($isMarked) {
+            continue
+        }
+
+        $violations.Add([pscustomobject]@{
+                file     = $relativePath
+                line     = $lineNumber
+                ruleName = 'CompatCoreOnlyMember'
+                severity = 'Error'
+                message  = "Access to the .NET Core-only member '.$memberName' is undefined on Windows PowerShell 5.1 and throws under StrictMode. $($memberSpec.Remediation) (If this access is deliberately runtime-guarded, annotate the line with '# compat-core-member-ok'.)"
+            }) | Out-Null
+    }
+
+    return , @($violations.ToArray())
+}
+
 function Get-FindingCommandName {
     # Extracts the command name from a PSUseCompatibleCommands diagnostic message, which
     # always contains "command '<name>'".
@@ -419,6 +545,12 @@ foreach ($target in $targets) {
 
     # Analyzer-invisible class: Invoke-WebRequest missing -UseBasicParsing.
     foreach ($violation in (Get-WebRequestParsingViolation -FilePath $target -RepositoryRoot $repositoryRoot)) {
+        Add-RealFinding -Collection $realFindings -SeenKeys $seenKeys -Record $violation
+    }
+
+    # Analyzer-invisible class: .NET Core-only instance members (ProcessStartInfo.ArgumentList,
+    # FileSystemInfo.ResolveLinkTarget) that throw on Windows PowerShell 5.1.
+    foreach ($violation in (Get-CoreOnlyMemberViolation -FilePath $target -RepositoryRoot $repositoryRoot)) {
         Add-RealFinding -Collection $realFindings -SeenKeys $seenKeys -Record $violation
     }
 }

--- a/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
@@ -1,0 +1,465 @@
+<#
+.SYNOPSIS
+    Static cross-version compatibility gate for Windows PowerShell 5.1 <-> PowerShell 7+.
+
+.DESCRIPTION
+    Runs the PSScriptAnalyzer compatibility rules (PSUseCompatibleSyntax,
+    PSUseCompatibleCommands, PSUseCompatibleTypes) against repository PowerShell sources
+    targeting both Windows PowerShell 5.1 (Desktop / .NET Framework) and PowerShell 7+
+    (Core). Any finding that is not a known false positive fails the gate with a stable
+    E_COMPAT_INCOMPATIBILITY diagnostic.
+
+    False positives are handled in exactly two sanctioned ways:
+      - Inline [Diagnostics.CodeAnalysis.SuppressMessageAttribute] with a justification,
+        for guarded native calls (honored natively by PSScriptAnalyzer).
+      - The AllowedCommands list in compatibility-allowlist.psd1, for external
+        executables and runtime-installed module commands (for example Pester 5).
+
+    This script must itself remain runnable on Windows PowerShell 5.1: no ternary,
+    null-coalescing, pipeline-chain operators, $IsWindows/$IsMacOS/$IsLinux references,
+    or .NET Core-only APIs.
+
+.PARAMETER Path
+    Repository root (or any directory) to scan recursively. Defaults to the repository
+    root inferred from this script's location.
+
+.PARAMETER TargetFiles
+    Optional explicit list of .ps1/.psm1 files to check instead of a recursive scan.
+    Files that do not exist are skipped with a diagnostic; an input that resolves to zero
+    existing targets skips cleanly without widening to a full-repo scan.
+
+.PARAMETER OutputFormat
+    'text' (default) for human-readable output, or 'json' for a machine-readable record.
+
+.OUTPUTS
+    Exit code 0 when no real incompatibilities remain; 1 otherwise.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string[]]$TargetFiles,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('text', 'json')]
+    [string]$OutputFormat = 'text'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+# Repo root is three levels up: Scripts/Utils/Quality -> repo root.
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path -Path $scriptRoot -ChildPath "../../..")).Path
+
+if ([string]::IsNullOrWhiteSpace($Path)) {
+    $Path = $repositoryRoot
+}
+
+function Resolve-CompatibilityProfile {
+    # Picks an installed PSScriptAnalyzer compatibility profile matching a filename
+    # pattern, so the gate stays robust across analyzer versions instead of pinning an
+    # exact build number that may not exist in the installed module.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProfileDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    $profileMatches = @(Get-ChildItem -Path $ProfileDirectory -Filter $Pattern -File -ErrorAction SilentlyContinue |
+            Sort-Object -Property Name)
+    if ($profileMatches.Count -eq 0) {
+        throw "E_COMPAT_PROFILE_MISSING: No PSScriptAnalyzer compatibility profile found for $Description (pattern '$Pattern') under '$ProfileDirectory'."
+    }
+
+    # Profile id is the file name without the .json extension.
+    return [System.IO.Path]::GetFileNameWithoutExtension($profileMatches[0].FullName)
+}
+
+function Get-CompatibilityTargetProfile {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+
+    $analyzerModule = Get-Module -ListAvailable -Name PSScriptAnalyzer |
+        Sort-Object -Property Version -Descending |
+        Select-Object -First 1
+    if ($null -eq $analyzerModule) {
+        throw "E_COMPAT_ANALYZER_MISSING: PSScriptAnalyzer module is not installed. Install it with 'Install-Module PSScriptAnalyzer -Scope CurrentUser'."
+    }
+
+    $profileDirectory = Join-Path -Path $analyzerModule.ModuleBase -ChildPath "compatibility_profiles"
+    if (-not (Test-Path -LiteralPath $profileDirectory -PathType Container)) {
+        throw "E_COMPAT_PROFILE_DIR_MISSING: PSScriptAnalyzer compatibility_profiles directory not found at '$profileDirectory'."
+    }
+
+    $windowsPowerShell = Resolve-CompatibilityProfile -ProfileDirectory $profileDirectory -Pattern "win-*5.1*framework.json" -Description "Windows PowerShell 5.1 (Desktop)"
+    $powerShellCoreWindows = Resolve-CompatibilityProfile -ProfileDirectory $profileDirectory -Pattern "win-*_7.*_core.json" -Description "PowerShell 7+ (Windows)"
+    $powerShellCoreLinux = Resolve-CompatibilityProfile -ProfileDirectory $profileDirectory -Pattern "ubuntu_*_7.*_core.json" -Description "PowerShell 7+ (Linux)"
+
+    return @($windowsPowerShell, $powerShellCoreWindows, $powerShellCoreLinux)
+}
+
+function Get-AllowedCommandData {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AllowlistPath
+    )
+
+    if (-not (Test-Path -LiteralPath $AllowlistPath -PathType Leaf)) {
+        throw "E_COMPAT_ALLOWLIST_MISSING: Compatibility allowlist not found at '$AllowlistPath'."
+    }
+
+    $data = Import-PowerShellDataFile -LiteralPath $AllowlistPath
+    $externalExecutables = @()
+    if ($data.ContainsKey('ExternalExecutables')) {
+        $externalExecutables = @($data['ExternalExecutables'])
+    }
+    $moduleCommands = @()
+    if ($data.ContainsKey('ModuleCommands')) {
+        $moduleCommands = @($data['ModuleCommands'])
+    }
+
+    return @{
+        ExternalExecutables = $externalExecutables
+        ModuleCommands      = $moduleCommands
+    }
+}
+
+function Get-CompatibilityTargetFile {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [string[]]$ExplicitFiles
+    )
+
+    if ($null -ne $ExplicitFiles -and $ExplicitFiles.Count -gt 0) {
+        $resolved = New-Object System.Collections.Generic.List[string]
+        foreach ($candidate in $ExplicitFiles) {
+            if ([string]::IsNullOrWhiteSpace($candidate)) {
+                continue
+            }
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                $resolved.Add((Resolve-Path -LiteralPath $candidate).Path)
+            } else {
+                Write-Warning "W_COMPAT_TARGET_MISSING: Skipping non-existent target '$candidate'."
+            }
+        }
+        return , @($resolved.ToArray())
+    }
+
+    $found = @(Get-ChildItem -Path $RootPath -Recurse -File -Include *.ps1, *.psm1 -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '(\\|/)\.git(\\|/)' } |
+            ForEach-Object { $_.FullName } |
+            Sort-Object)
+    return , @($found)
+}
+
+function Get-AutomaticVariableViolation {
+    # Detects bare references to OS/style automatic variables that do not exist on
+    # Windows PowerShell 5.1 ($IsWindows/$IsMacOS/$IsLinux/$PSStyle). Under StrictMode a
+    # bare reference THROWS on 5.1, and PSScriptAnalyzer's compatibility rules cannot see
+    # this class of incompatibility. Uses the AST so matches inside comments or string
+    # literals are not flagged. The compatibility shim itself is exempt because it reads
+    # these variables by name through Get-Variable, never as bare references.
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
+    )
+
+    $forbiddenNames = @('IsWindows', 'IsMacOS', 'IsLinux', 'IsCoreCLR', 'PSStyle')
+    $violations = New-Object System.Collections.Generic.List[object]
+
+    $fileName = Split-Path -Path $FilePath -Leaf
+    if ($fileName -eq 'CompatibilityHelpers.ps1') {
+        return , @($violations.ToArray())
+    }
+
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($FilePath, [ref]$tokens, [ref]$parseErrors)
+    if ($null -eq $ast) {
+        return , @($violations.ToArray())
+    }
+
+    $variableAsts = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.VariableExpressionAst]
+        }, $true)
+
+    $relativePath = $FilePath
+    if ($FilePath.StartsWith($RepositoryRoot)) {
+        $relativePath = $FilePath.Substring($RepositoryRoot.Length).TrimStart([char[]]@('/', '\'))
+    }
+    $relativePath = $relativePath.Replace('\', '/')
+
+    foreach ($variableAst in $variableAsts) {
+        $variableName = $variableAst.VariablePath.UserPath
+        if ($forbiddenNames -contains $variableName) {
+            $violations.Add([pscustomobject]@{
+                    file     = $relativePath
+                    line     = $variableAst.Extent.StartLineNumber
+                    ruleName = 'CompatAutomaticVariable'
+                    severity = 'Error'
+                    message  = "The automatic variable '`$$variableName' is undefined on Windows PowerShell 5.1 and throws under StrictMode. Use the Test-Is*Platform helpers from CompatibilityHelpers.ps1 instead."
+                })
+        }
+    }
+
+    return , @($violations.ToArray())
+}
+
+function Get-WebRequestParsingViolation {
+    # Flags Invoke-WebRequest calls that omit -UseBasicParsing. On Windows PowerShell 5.1
+    # the default response parser uses the Internet Explorer engine, which throws on hosts
+    # where IE first-launch configuration is incomplete (servers, CI). -UseBasicParsing is a
+    # harmless no-op on PowerShell 7+. PSScriptAnalyzer cannot model this default-behavior
+    # divergence, so it is checked here via the AST.
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
+    )
+
+    $violations = New-Object System.Collections.Generic.List[object]
+
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($FilePath, [ref]$tokens, [ref]$parseErrors)
+    if ($null -eq $ast) {
+        return , @($violations.ToArray())
+    }
+
+    $relativePath = $FilePath
+    if ($FilePath.StartsWith($RepositoryRoot)) {
+        $relativePath = $FilePath.Substring($RepositoryRoot.Length).TrimStart([char[]]@('/', '\'))
+    }
+    $relativePath = $relativePath.Replace('\', '/')
+
+    $commandAsts = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst]
+        }, $true)
+
+    foreach ($commandAst in $commandAsts) {
+        $commandName = $commandAst.GetCommandName()
+        if ($null -eq $commandName) {
+            continue
+        }
+        # Only the cmdlet and its built-in alias are flagged. The curl/wget aliases are
+        # intentionally excluded: on Linux/macOS they resolve to the real native binaries,
+        # which have nothing to do with the IE-engine parsing behavior.
+        if (@('Invoke-WebRequest', 'iwr') -notcontains $commandName) {
+            continue
+        }
+
+        $hasUseBasicParsing = $false
+        foreach ($element in $commandAst.CommandElements) {
+            if ($element -is [System.Management.Automation.Language.CommandParameterAst] -and
+                $element.ParameterName -like 'UseBasicParsing*') {
+                $hasUseBasicParsing = $true
+                break
+            }
+        }
+
+        if (-not $hasUseBasicParsing) {
+            $violations.Add([pscustomobject]@{
+                    file     = $relativePath
+                    line     = $commandAst.Extent.StartLineNumber
+                    ruleName = 'CompatWebRequestParsing'
+                    severity = 'Error'
+                    message  = "Invoke-WebRequest must pass -UseBasicParsing for Windows PowerShell 5.1 compatibility (the IE parser is unavailable on many 5.1 hosts; -UseBasicParsing is a no-op on 7+)."
+                })
+        }
+    }
+
+    return , @($violations.ToArray())
+}
+
+function Get-FindingCommandName {
+    # Extracts the command name from a PSUseCompatibleCommands diagnostic message, which
+    # always contains "command '<name>'".
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $match = [regex]::Match($Message, "command '([^']+)'")
+    if ($match.Success) {
+        return $match.Groups[1].Value
+    }
+
+    return ''
+}
+
+# --- Resolve configuration -------------------------------------------------------------
+
+$allowlistPath = Join-Path -Path $scriptRoot -ChildPath "compatibility-allowlist.psd1"
+$allowedCommandData = Get-AllowedCommandData -AllowlistPath $allowlistPath
+$allowedExternalExecutables = @($allowedCommandData['ExternalExecutables'])
+$allowedModuleCommands = @($allowedCommandData['ModuleCommands'])
+$targetProfiles = Get-CompatibilityTargetProfile
+$targets = Get-CompatibilityTargetFile -RootPath $Path -ExplicitFiles $TargetFiles
+
+if ($targets.Count -eq 0) {
+    if ($OutputFormat -eq 'json') {
+        [pscustomobject]@{
+            status        = 'skipped'
+            reason        = 'no-targets'
+            findingCount  = 0
+            findings      = @()
+        } | ConvertTo-Json -Depth 5
+    } else {
+        Write-Host "No PowerShell targets to check; skipping compatibility gate."
+    }
+    exit 0
+}
+
+$analyzerSettings = @{
+    Rules = @{
+        PSUseCompatibleSyntax   = @{ Enable = $true; TargetVersions = @('5.1', '7.0') }
+        PSUseCompatibleCommands = @{ Enable = $true; TargetProfiles = $targetProfiles }
+        PSUseCompatibleTypes    = @{ Enable = $true; TargetProfiles = $targetProfiles }
+    }
+}
+
+$compatibilityRules = @('PSUseCompatibleSyntax', 'PSUseCompatibleCommands', 'PSUseCompatibleTypes')
+
+# --- Run analysis ----------------------------------------------------------------------
+
+$realFindings = New-Object System.Collections.Generic.List[object]
+$allowedFindingCount = 0
+# Collapse the per-platform duplication PSScriptAnalyzer emits (one finding per target
+# profile) into a single record keyed by file/line/rule and the platform-independent
+# message prefix.
+$seenKeys = New-Object System.Collections.Generic.HashSet[string]
+
+function Add-RealFinding {
+    param($Collection, $SeenKeys, $Record)
+
+    $messagePrefix = $Record.message
+    $byDefaultIndex = $messagePrefix.IndexOf(' by default in PowerShell version')
+    if ($byDefaultIndex -ge 0) {
+        $messagePrefix = $messagePrefix.Substring(0, $byDefaultIndex)
+    }
+    $key = "{0}|{1}|{2}|{3}" -f $Record.file, $Record.line, $Record.ruleName, $messagePrefix
+    if ($SeenKeys.Add($key)) {
+        $Collection.Add($Record)
+    }
+}
+
+foreach ($target in $targets) {
+    $findings = @(Invoke-ScriptAnalyzer -Path $target -IncludeRule $compatibilityRules -Settings $analyzerSettings -ErrorAction Stop)
+    foreach ($finding in $findings) {
+        if ($finding.RuleName -eq 'PSUseCompatibleCommands') {
+            $commandName = Get-FindingCommandName -Message $finding.Message
+            if (-not [string]::IsNullOrEmpty($commandName)) {
+                # A parameter-level finding ("The parameter 'X' is not available for command
+                # 'Y'...") is a REAL incompatibility for a built-in cmdlet, so external
+                # executables only suppress the command-absence shape. Module-provided
+                # commands (Pester DSL) suppress both shapes because the whole command is
+                # supplied at runtime and works on both editions.
+                $isParameterFinding = $finding.Message.TrimStart().StartsWith('The parameter ')
+                $isModuleCommand = $allowedModuleCommands -contains $commandName
+                $isExternalExecutable = $allowedExternalExecutables -contains $commandName
+                if ($isModuleCommand -or ($isExternalExecutable -and -not $isParameterFinding)) {
+                    $allowedFindingCount = $allowedFindingCount + 1
+                    continue
+                }
+            }
+        }
+
+        $relativePath = $target
+        if ($target.StartsWith($repositoryRoot)) {
+            $relativePath = $target.Substring($repositoryRoot.Length).TrimStart([char[]]@('/', '\'))
+        }
+        $relativePath = $relativePath.Replace('\', '/')
+
+        Add-RealFinding -Collection $realFindings -SeenKeys $seenKeys -Record ([pscustomobject]@{
+                file     = $relativePath
+                line     = $finding.Line
+                ruleName = $finding.RuleName
+                severity = [string]$finding.Severity
+                message  = $finding.Message
+            })
+    }
+
+    # Analyzer-invisible class: bare 5.1-undefined automatic variables.
+    foreach ($violation in (Get-AutomaticVariableViolation -FilePath $target -RepositoryRoot $repositoryRoot)) {
+        Add-RealFinding -Collection $realFindings -SeenKeys $seenKeys -Record $violation
+    }
+
+    # Analyzer-invisible class: Invoke-WebRequest missing -UseBasicParsing.
+    foreach ($violation in (Get-WebRequestParsingViolation -FilePath $target -RepositoryRoot $repositoryRoot)) {
+        Add-RealFinding -Collection $realFindings -SeenKeys $seenKeys -Record $violation
+    }
+}
+
+# --- Report ----------------------------------------------------------------------------
+
+$sortedFindings = @($realFindings | Sort-Object -Property file, line)
+
+if ($sortedFindings.Count -eq 0) {
+    $resultStatus = 'pass'
+} else {
+    $resultStatus = 'fail'
+}
+
+if ($OutputFormat -eq 'json') {
+    [pscustomobject]@{
+        status              = $resultStatus
+        targetCount         = $targets.Count
+        targetProfiles      = $targetProfiles
+        allowedFindingCount = $allowedFindingCount
+        findingCount        = $sortedFindings.Count
+        findings            = $sortedFindings
+    } | ConvertTo-Json -Depth 6
+} else {
+    Write-Host "Cross-version compatibility gate (Windows PowerShell 5.1 + PowerShell 7+)"
+    Write-Host "  Targets scanned : $($targets.Count)"
+    Write-Host "  Profiles        : $([string]::Join(', ', $targetProfiles))"
+    Write-Host "  Allowed (noise) : $allowedFindingCount finding(s) filtered via allowlist/suppression"
+    if ($sortedFindings.Count -eq 0) {
+        Write-Host "  Result          : PASS - no cross-version incompatibilities detected."
+    } else {
+        Write-Host "  Result          : FAIL - $($sortedFindings.Count) incompatibilit(ies) detected:"
+        foreach ($finding in $sortedFindings) {
+            Write-Host ("    {0}:{1} [{2}] {3}" -f $finding.file, $finding.line, $finding.ruleName, $finding.message)
+        }
+    }
+}
+
+if ($sortedFindings.Count -gt 0) {
+    Write-Error "E_COMPAT_INCOMPATIBILITY: $($sortedFindings.Count) cross-version incompatibilit(ies) detected. Fix in code (portable idiom) or add a justified SuppressMessageAttribute / allowlist entry."
+    exit 1
+}
+
+exit 0

--- a/Scripts/Utils/Quality/Invoke-PreCommitWithRecovery.ps1
+++ b/Scripts/Utils/Quality/Invoke-PreCommitWithRecovery.ps1
@@ -25,6 +25,12 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_PRECOMMIT_RECOVERY_PREREQ_MISSING: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+. $compatibilityHelpersPath
+
 function Get-PreCommitExecutableOrThrow {
     $preCommitCommand = Get-Command -Name "pre-commit" -ErrorAction SilentlyContinue
     if ($null -eq $preCommitCommand) {
@@ -54,9 +60,8 @@ function Invoke-PreCommitCapturedCommand {
     $processStartInfo.RedirectStandardOutput = $true
     $processStartInfo.RedirectStandardError = $true
 
-    foreach ($argument in @($Arguments)) {
-        [void]$processStartInfo.ArgumentList.Add($argument)
-    }
+    # ProcessStartInfo.ArgumentList is .NET Core-only; see Set-PortableProcessArguments.
+    Set-PortableProcessArguments -StartInfo $processStartInfo -ArgumentList $Arguments
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $processStartInfo
@@ -67,7 +72,7 @@ function Invoke-PreCommitCapturedCommand {
         $exited = $process.WaitForExit($CommandTimeoutSeconds * 1000)
         if (-not $exited) {
             try {
-                $process.Kill($true)
+                Stop-ProcessTreePortably -Process $process
             }
             catch {
                 Write-Verbose "Pre-commit recovery cleanup diagnostics: failed to kill timed-out process: $($_.Exception.Message)"

--- a/Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1
@@ -310,8 +310,11 @@ function Invoke-AutoHotkeyCommand {
 
     # Process-level capture is more reliable than call-operator redirection for GUI-subsystem
     # binaries (such as AutoHotkey64.exe on CI), and keeps behavior consistent cross-platform.
-    # Uses System.Diagnostics.Process with ArgumentList.Add() on all platforms to avoid
-    # Start-Process -ArgumentList mangling of special characters (curly braces, double quotes).
+    # Argument passing goes through Set-PortableProcessArguments so special characters (curly
+    # braces, double quotes) are escaped exactly as .NET Core's ArgumentList would, without the
+    # Start-Process -ArgumentList mangling: it uses the native ArgumentList collection on
+    # PowerShell 7+ and an equivalently escaped .Arguments string on Windows PowerShell 5.1,
+    # whose .NET Framework ProcessStartInfo has no ArgumentList property.
     $process = $null
     $stdoutLines = @()
     $stderrLines = @()
@@ -327,9 +330,7 @@ function Invoke-AutoHotkeyCommand {
         $startInfo.UseShellExecute = $false
         $startInfo.CreateNoWindow = $true
 
-        foreach ($argument in $Arguments) {
-            [void]$startInfo.ArgumentList.Add($argument)
-        }
+        Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList $Arguments
 
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo

--- a/Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1
@@ -16,6 +16,13 @@ if (-not (Test-Path -Path $diagnosticsHelpersPath -PathType Leaf)) {
 
 .$diagnosticsHelpersPath
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+.$compatibilityHelpersPath
+
 function Convert-OutputToStringArray {
     param(
         [Parameter(Mandatory = $false)]
@@ -185,7 +192,7 @@ function ConvertTo-RepositoryRelativePath {
         [string]$Path
     )
 
-    return ([System.IO.Path]::GetRelativePath($RepoRoot, $Path)).Replace([System.IO.Path]::DirectorySeparatorChar, '/').Replace([System.IO.Path]::AltDirectorySeparatorChar, '/')
+    return (Get-RelativePathCompat -BasePath $RepoRoot -TargetPath $Path).Replace([System.IO.Path]::DirectorySeparatorChar, '/').Replace([System.IO.Path]::AltDirectorySeparatorChar, '/')
 }
 
 function Test-IsPathUnderDirectory {
@@ -203,7 +210,7 @@ function Test-IsPathUnderDirectory {
 
     $resolvedDirectory = (Resolve-Path -LiteralPath $DirectoryPath -ErrorAction Stop).Path
     $resolvedPath = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
-    $relative = [System.IO.Path]::GetRelativePath($resolvedDirectory, $resolvedPath)
+    $relative = Get-RelativePathCompat -BasePath $resolvedDirectory -TargetPath $resolvedPath
     if ([string]::IsNullOrWhiteSpace($relative)) {
         return $true
     }
@@ -237,7 +244,7 @@ function Repair-AutoHotkeyStaticViolation {
     $scriptSourceRoot = Join-Path -Path $RepoRoot -ChildPath "Scripts/AutoHotKey"
 
     if ($HasV1Syntax -and (Test-IsPathUnderDirectory -DirectoryPath $configRoot -Path $File.FullName)) {
-        $relativeConfigPath = [System.IO.Path]::GetRelativePath($configRoot, $File.FullName)
+        $relativeConfigPath = Get-RelativePathCompat -BasePath $configRoot -TargetPath $File.FullName
         $sourceCandidate = Join-Path -Path $scriptSourceRoot -ChildPath $relativeConfigPath
         if (Test-Path -LiteralPath $sourceCandidate -PathType Leaf) {
             $sourceContent = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $sourceCandidate).Path, [System.Text.Encoding]::UTF8)
@@ -815,7 +822,7 @@ function Test-BatchScriptsStaticSmoke {
         for ($index = 0; $index -lt $lines.Count; $index++) {
             $line = $lines[$index]
             $lineNumber = $index + 1
-            $relative = [System.IO.Path]::GetRelativePath($RepoRoot,$file.FullName)
+            $relative = Get-RelativePathCompat -BasePath $RepoRoot -TargetPath $file.FullName
 
             if ($line -match "\s+$") {
                 $violations.Add("${relative}:$lineNumber trailing whitespace") | Out-Null
@@ -846,7 +853,7 @@ function Test-BatchScriptsStaticSmoke {
         }
 
         if ($parenBalance -ne 0) {
-            $relative = [System.IO.Path]::GetRelativePath($RepoRoot,$file.FullName)
+            $relative = Get-RelativePathCompat -BasePath $RepoRoot -TargetPath $file.FullName
             $violations.Add("$relative unbalanced parentheses at end-of-file") | Out-Null
         }
     }

--- a/Scripts/Utils/Quality/Test-LlmHarness.ps1
+++ b/Scripts/Utils/Quality/Test-LlmHarness.ps1
@@ -22,6 +22,13 @@ if (-not (Test-Path -Path $llmWrapperHelpersPath -PathType Leaf)) {
 
 .$llmWrapperHelpersPath
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+.$compatibilityHelpersPath
+
 function Get-RepositoryRoot {
     param(
         [Parameter(Mandatory = $false)]
@@ -114,7 +121,7 @@ function Test-IsPathWithinDirectory {
         [string]$CandidatePath
     )
 
-    $relativePath = [System.IO.Path]::GetRelativePath($BasePath,$CandidatePath)
+    $relativePath = Get-RelativePathCompat -BasePath $BasePath -TargetPath $CandidatePath
     if ([string]::IsNullOrWhiteSpace($relativePath) -or $relativePath -eq '.') {
         return $true
     }
@@ -239,7 +246,7 @@ if ($llmMarkdownFiles.Count -eq 0) {
 
 foreach ($file in $llmMarkdownFiles) {
     $lineCount = [System.IO.File]::ReadAllLines($file.FullName,[System.Text.Encoding]::UTF8).Length
-    $relativePath = [System.IO.Path]::GetRelativePath($repoRoot,$file.FullName)
+    $relativePath = Get-RelativePathCompat -BasePath $repoRoot -TargetPath $file.FullName
 
     if ($lineCount -gt $MaxLines) {
         $errors.Add("$relativePath exceeds max line limit ($lineCount > $MaxLines)") | Out-Null
@@ -273,7 +280,7 @@ $anchorLinkPattern = '\[[^\]]+\]\(\.\./skill-details/(?<detailsPath>(?:[^/#)\s]+
 $detailsAnchorsByPath = @{}
 foreach ($skillFile in $skillFiles) {
     $skillContent = [System.IO.File]::ReadAllText($skillFile.FullName,[System.Text.Encoding]::UTF8)
-    $relativePath = [System.IO.Path]::GetRelativePath($repoRoot,$skillFile.FullName)
+    $relativePath = Get-RelativePathCompat -BasePath $repoRoot -TargetPath $skillFile.FullName
 
     $match = [regex]::Match($skillContent,$triggerPattern,[System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
     if (-not $match.Success) {

--- a/Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1
+++ b/Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1
@@ -11,6 +11,13 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $script:InvariantCultureName = [System.Globalization.CultureInfo]::InvariantCulture.Name
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+.$compatibilityHelpersPath
+
 function Get-RepositoryRoot {
     param(
         [Parameter(Mandatory = $false)]
@@ -192,13 +199,13 @@ function Get-SkillMetadata {
     )
 
     if (-not $match.Success) {
-        $relative = [System.IO.Path]::GetRelativePath($Root,$SkillPath)
+        $relative = Get-RelativePathCompat -BasePath $Root -TargetPath $SkillPath
         throw "E_LLM_TRIGGER_METADATA_MISSING: Missing trigger metadata comment in '$relative'."
     }
 
     $category = $match.Groups['category'].Value.Trim()
 
-    $relativePath = ConvertTo-PortablePath -PathValue ([System.IO.Path]::GetRelativePath($Root,$SkillPath))
+    $relativePath = ConvertTo-PortablePath -PathValue (Get-RelativePathCompat -BasePath $Root -TargetPath $SkillPath)
     $skillLinkPath = $relativePath
     if ($skillLinkPath.StartsWith('.llm/',[System.StringComparison]::OrdinalIgnoreCase)) {
         $skillLinkPath = $skillLinkPath.Substring(5)

--- a/Scripts/Utils/Quality/compatibility-allowlist.psd1
+++ b/Scripts/Utils/Quality/compatibility-allowlist.psd1
@@ -1,0 +1,67 @@
+@{
+    # Findings reported by PSUseCompatibleCommands that are NOT real Windows PowerShell 5.1
+    # incompatibilities, split by category so the gate can suppress them precisely.
+    #
+    # ExternalExecutables: native programs invoked by name. The analyzer compares against
+    #   built-in PowerShell command profiles, so any external program reads as "command not
+    #   available". ONLY the command-absence finding is suppressed for these; a parameter
+    #   finding (which cannot occur for a native program) would still surface.
+    #
+    # ModuleCommands: commands provided by a runtime-installed module (Pester 5 DSL). These
+    #   work on both editions once the module is installed but are absent from the built-in
+    #   platform profiles, so BOTH the command-absence AND any parameter findings for them
+    #   are false positives and suppressed.
+    #
+    # Neither list may contain a real built-in PowerShell cmdlet whose parameters/behavior
+    # actually differ across editions (for example ConvertTo-Json, New-Item). Genuine
+    # incompatibilities are fixed in code or suppressed inline with a justified
+    # SuppressMessageAttribute, never hidden here. Enforced by
+    # Tests/Utils/CompatibilityConventions.Tests.ps1.
+    ExternalExecutables = @(
+        'node'
+        'npm'
+        'npx'
+        'git'
+        'gh'
+        'dotnet'
+        'pwsh'
+        'powershell'
+        'pandoc'
+        'robocopy'
+        'scoop'
+        'winget'
+        'komorebic'
+        'pshazz'
+        'pre-commit'
+        'shfmt'
+        'shellcheck'
+        'stylua'
+        'actionlint'
+        'pbcopy'
+        'xclip'
+        'xsel'
+        'wl-copy'
+    )
+
+    ModuleCommands = @(
+        'Invoke-Pester'
+        'Describe'
+        'Context'
+        'It'
+        'Should'
+        'BeforeAll'
+        'AfterAll'
+        'BeforeEach'
+        'AfterEach'
+        'BeforeDiscovery'
+        'Mock'
+        'Assert-MockCalled'
+        'Assert-VerifiableMock'
+        'New-PesterConfiguration'
+        'New-MockObject'
+        'Set-ItResult'
+        'InModuleScope'
+        'Add-ShouldOperator'
+        'Get-MockDynamicParameter'
+    )
+}

--- a/Scripts/Utils/Remove-BOM.ps1
+++ b/Scripts/Utils/Remove-BOM.ps1
@@ -317,7 +317,7 @@ function Resolve-TopLevelPathAlias {
             $resolvedAliasTarget = $null
             if ($topLevelItem.PSObject.Methods.Name -contains "ResolveLinkTarget") {
                 try {
-                    $resolvedAliasTarget = $topLevelItem.ResolveLinkTarget($true)
+                    $resolvedAliasTarget = $topLevelItem.ResolveLinkTarget($true) # compat-core-member-ok: guarded by the PSObject.Methods probe above; Windows PowerShell 5.1 uses the LinkTarget/Target ETS branch below.
                 }
                 catch {
                     $resolvedAliasTarget = $null
@@ -329,10 +329,16 @@ function Resolve-TopLevelPathAlias {
                 $aliasResolutionSource = "ResolveLinkTarget"
             }
             else {
+                # Windows PowerShell 5.1 surfaces symlink targets through the LinkTarget/Target
+                # ETS members. This single-hop top-level-alias read is intentionally kept inline
+                # (it is a hardening invariant pinned by ScriptSafetyConventions.Tests.ps1) and
+                # is distinct from the chain-following Get-PortableLinkTarget used for full
+                # scan-root canonicalization. The .LinkTarget member access is .NET 6-only but
+                # is reached only after the PSObject.Properties capability check below.
                 $linkTargetProperty = $null
                 $linkTargetPropertyName = $null
                 if ($topLevelItem.PSObject.Properties.Name -contains "LinkTarget") {
-                    $linkTargetProperty = [string]$topLevelItem.LinkTarget
+                    $linkTargetProperty = [string]$topLevelItem.LinkTarget # compat-core-member-ok: guarded by the PSObject.Properties check above.
                     $linkTargetPropertyName = "LinkTarget"
                 }
                 elseif ($topLevelItem.PSObject.Properties.Name -contains "Target") {
@@ -487,18 +493,13 @@ function Resolve-CanonicalFileSystemPath {
         $resolvedPath = (Resolve-Path -LiteralPath $path -ErrorAction Stop).Path
         $resolvedItem = Get-Item -LiteralPath $resolvedPath -ErrorAction Stop
 
-        $resolvedLinkTarget = $null
-        if ($resolvedItem.PSObject.Methods.Name -contains "ResolveLinkTarget") {
-            try {
-                $resolvedLinkTarget = $resolvedItem.ResolveLinkTarget($true)
-            }
-            catch {
-                $resolvedLinkTarget = $null
-            }
-        }
-
-        $canonicalCandidate = if ($null -ne $resolvedLinkTarget) {
-            $resolvedLinkTarget.FullName
+        # Resolve a symlinked scan root to its final target so git-native discovery (which
+        # keys on the real worktree path) can scope correctly. Get-PortableLinkTarget uses the
+        # native ResolveLinkTarget on PowerShell 7+ and the LinkTarget/Target ETS members on
+        # Windows PowerShell 5.1, whose .NET Framework FileSystemInfo has no ResolveLinkTarget.
+        $resolvedLinkTargetPath = Get-PortableLinkTarget -Item $resolvedItem
+        $canonicalCandidate = if (-not [string]::IsNullOrWhiteSpace($resolvedLinkTargetPath)) {
+            $resolvedLinkTargetPath
         }
         else {
             $resolvedItem.FullName

--- a/Scripts/Utils/Remove-BOM.ps1
+++ b/Scripts/Utils/Remove-BOM.ps1
@@ -23,6 +23,13 @@ param(
 
 $script:prefixReadFailures = 0
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_REMOVE_BOM_COMPAT_HELPERS_MISSING: Compatibility helper file not found at '$compatibilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $compatibilityHelpersPath
+
 function Get-DefaultExclusionPatterns {
     return @(
         # Version control
@@ -178,7 +185,7 @@ function Test-IsPathUnderRoot {
     $normalizedPath = ((Resolve-TopLevelPathAlias -Path $path) -replace '\\', '/').TrimEnd('/')
     $normalizedRoot = ((Resolve-TopLevelPathAlias -Path $root) -replace '\\', '/').TrimEnd('/')
 
-    $comparison = if ($IsWindows) {
+    $comparison = if (Test-IsWindowsPlatform) {
         [System.StringComparison]::OrdinalIgnoreCase
     }
     else {
@@ -202,7 +209,7 @@ function Resolve-UnixPhysicalPath {
         [string]$path
     )
 
-    if ($IsWindows -or [string]::IsNullOrWhiteSpace($path)) {
+    if ((Test-IsWindowsPlatform) -or [string]::IsNullOrWhiteSpace($path)) {
         return $null
     }
 
@@ -280,7 +287,7 @@ function Resolve-TopLevelPathAlias {
 
     $fullPath = [System.IO.Path]::GetFullPath($path)
 
-    if ($IsWindows -or [string]::IsNullOrWhiteSpace($fullPath) -or -not $fullPath.StartsWith('/')) {
+    if ((Test-IsWindowsPlatform) -or [string]::IsNullOrWhiteSpace($fullPath) -or -not $fullPath.StartsWith('/')) {
         return $fullPath
     }
 
@@ -377,7 +384,7 @@ function Resolve-TopLevelPathAlias {
                 # Unix-specific fallback: readlink resolves symlinks that
                 # .NET/PowerShell providers may not detect (for example macOS
                 # /var -> /private/var, where readlink returns relative target "private/var").
-                if (-not $IsWindows -and $resolvedTopLevelAliasTarget.Equals($topLevelSegment, [System.StringComparison]::Ordinal)) {
+                if (-not (Test-IsWindowsPlatform) -and $resolvedTopLevelAliasTarget.Equals($topLevelSegment, [System.StringComparison]::Ordinal)) {
                     try {
                         $readlinkOutput = (& readlink $topLevelSegment 2>$null)
                         if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($readlinkOutput)) {
@@ -400,7 +407,7 @@ function Resolve-TopLevelPathAlias {
                     }
                 }
 
-                if (-not $IsWindows -and $resolvedTopLevelAliasTarget.Equals($topLevelSegment, [System.StringComparison]::Ordinal)) {
+                if (-not (Test-IsWindowsPlatform) -and $resolvedTopLevelAliasTarget.Equals($topLevelSegment, [System.StringComparison]::Ordinal)) {
                     $physicalTopLevelPath = Resolve-UnixPhysicalPath -Path $topLevelSegment
                     if (-not [string]::IsNullOrWhiteSpace($physicalTopLevelPath)) {
                         $physicalTopLevelPath = [System.IO.Path]::GetFullPath($physicalTopLevelPath)
@@ -704,7 +711,7 @@ function Resolve-ScannableFileDiscovery {
         $gitDiscoveryFailureReason = "git command not found on PATH"
     }
 
-    $comparison = if ($IsWindows) {
+    $comparison = if (Test-IsWindowsPlatform) {
         [System.StringComparison]::OrdinalIgnoreCase
     }
     else {
@@ -810,10 +817,7 @@ function Get-ScannableFiles {
         $canonicalGitRoot = Resolve-TopLevelPathAlias -Path $scanPlan.GitRoot
         $canonicalScanRoot = Resolve-TopLevelPathAlias -Path $scanPlan.ResolvedScanRoot
         try {
-            $scopeDiagnostics = [System.IO.Path]::GetRelativePath(
-                $canonicalGitRoot,
-                $canonicalScanRoot
-            )
+            $scopeDiagnostics = Get-RelativePathCompat -BasePath $canonicalGitRoot -TargetPath $canonicalScanRoot
         }
         catch {
             $scopeDiagnostics = $null

--- a/Scripts/Utils/Run-PreCommitValidation.ps1
+++ b/Scripts/Utils/Run-PreCommitValidation.ps1
@@ -46,6 +46,13 @@ if (-not (Test-Path -Path $llmWrapperHelpersPath -PathType Leaf)) {
 
 .$llmWrapperHelpersPath
 
+$compatibilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "Common/CompatibilityHelpers.ps1"
+if (-not (Test-Path -Path $compatibilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: Compatibility helper file not found at '$compatibilityHelpersPath'."
+}
+
+.$compatibilityHelpersPath
+
 function New-LlmHarnessPattern {
     param(
         [Parameter(Mandatory = $true)]
@@ -316,7 +323,7 @@ function Write-IsolatedPesterFailureArtifact {
 
     $resolvedRepoRoot = Resolve-CanonicalPath -Path $RepoRoot
     $resolvedArtifactPath = [System.IO.Path]::GetFullPath($artifactPath)
-    $comparison = if ($IsWindows) {
+    $comparison = if (Test-IsWindowsPlatform) {
         [System.StringComparison]::OrdinalIgnoreCase
     }
     else {

--- a/Scripts/Utils/Run-PreCommitValidation.ps1
+++ b/Scripts/Utils/Run-PreCommitValidation.ps1
@@ -224,18 +224,22 @@ function Resolve-CanonicalPath {
 
         $candidateItem = Get-Item -LiteralPath $candidatePath -Force
         if (Test-IsLinkOrReparsePoint -Item $candidateItem) {
+            # Get-PortableLinkTarget resolves the final link target portably: it uses the
+            # native FileSystemInfo.ResolveLinkTarget($true) on PowerShell 7+ and the
+            # LinkTarget/Target ETS members on Windows PowerShell 5.1, whose .NET Framework
+            # FileSystemInfo has no ResolveLinkTarget method.
             try {
-                $linkTargetItem = $candidateItem.ResolveLinkTarget($true)
+                $linkTargetPath = Get-PortableLinkTarget -Item $candidateItem
             }
             catch {
                 throw "E_CONFIG_ERROR: unable to resolve symbolic link or reparse point '$candidatePath': $($_.Exception.Message)"
             }
 
-            if ($null -eq $linkTargetItem) {
+            if ([string]::IsNullOrWhiteSpace($linkTargetPath)) {
                 throw "E_CONFIG_ERROR: symbolic link or reparse point '$candidatePath' has no resolvable target."
             }
 
-            $currentPath = [System.IO.Path]::GetFullPath($linkTargetItem.FullName)
+            $currentPath = [System.IO.Path]::GetFullPath($linkTargetPath)
             continue
         }
 
@@ -674,21 +678,22 @@ function Invoke-PesterQualityGateInIsolatedProcess {
         $modulePathEntryCount = @($env:PSModulePath -split [regex]::Escape([string]$pathSeparator) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count
         Write-Verbose ("Isolated Pester environment diagnostics: inheritedModulePathEntryCount={0}" -f $modulePathEntryCount)
 
-        foreach ($argument in @(
-                "-NoLogo",
-                "-NoProfile",
-                "-NonInteractive",
-                "-File",
-                $pesterGateScriptPath,
-                "-TestPath",
-                $TestPath,
-                "-DiagnosticsPrefix",
-                $SuiteLabel,
-                "-OutputVerbosity",
-                $OutputVerbosity
-            )) {
-            [void]$startInfo.ArgumentList.Add($argument)
-        }
+        # ProcessStartInfo.ArgumentList is .NET Core-only; Set-PortableProcessArguments uses it
+        # on PowerShell 7+ and an equivalently escaped .Arguments string on Windows PowerShell
+        # 5.1, whose .NET Framework ProcessStartInfo has no ArgumentList property.
+        Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList @(
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            $pesterGateScriptPath,
+            "-TestPath",
+            $TestPath,
+            "-DiagnosticsPrefix",
+            $SuiteLabel,
+            "-OutputVerbosity",
+            $OutputVerbosity
+        )
 
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo

--- a/Scripts/WindowsTerminal/WindowsTerminalBackup.ps1
+++ b/Scripts/WindowsTerminal/WindowsTerminalBackup.ps1
@@ -9,7 +9,7 @@ Push-Location -LiteralPath $baseDirectory
 
 try {
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
 
     if (Test-Path -LiteralPath $sourcePath -PathType Leaf) {

--- a/Scripts/WindowsTerminal/WindowsTerminalRestore.ps1
+++ b/Scripts/WindowsTerminal/WindowsTerminalRestore.ps1
@@ -10,7 +10,7 @@ try {
     $windowsTerminalSettings = "$windowsTerminalConfigPath\settings.json"
     if (-not (Test-Path -LiteralPath $windowsTerminalConfigPath -PathType Container)) {
         Write-Host "Windows Terminal settings directory not found at $windowsTerminalConfigPath, creating..."
-        New-Item -ItemType Directory -LiteralPath $windowsTerminalConfigPath -Force
+        [System.IO.Directory]::CreateDirectory($windowsTerminalConfigPath) | Out-Null
     }
 
     $settingsPath = Join-Path -Path $baseDirectory -ChildPath 'Config'
@@ -26,7 +26,7 @@ try {
     $backupFolder = Join-Path -Path $HOME -ChildPath "Documents"
     $backupFolder = Join-Path -Path $backupFolder -ChildPath "WT_Settings_Backup"
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
-        New-Item -LiteralPath $backupFolder -ItemType Directory -Force | Out-Null
+        [System.IO.Directory]::CreateDirectory($backupFolder) | Out-Null
     }
 
     $currentBackupFile = Join-Path -Path $backupFolder -ChildPath "settings_backup_$timestamp.json"

--- a/Tests/Devcontainer/Post-Create.Tests.ps1
+++ b/Tests/Devcontainer/Post-Create.Tests.ps1
@@ -90,7 +90,9 @@ Describe "post-create.sh pre-commit integration" {
     }
 
     It "pre-warms pre-commit hook environments during install" {
-        $script:postCreateContent | Should -Match 'pre-commit\s+install\s+--install-hooks'
+        # Accept either the combined `install --install-hooks` form or the dedicated
+        # `install-hooks` subcommand; the bootstrap uses the latter to pre-warm environments.
+        $script:postCreateContent | Should -Match 'pre-commit\s+install(\s+--install-hooks\b|-hooks\b)'
     }
 
     It "configures core.hooksPath to .githooks" {

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -2,6 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 BeforeAll {
+    . "$PSScriptRoot/../../Scripts/Utils/Common/CompatibilityHelpers.ps1"
     . "$PSScriptRoot/../../Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1" -NoRun
 }
 
@@ -847,7 +848,7 @@ Describe "Convert-ReviewThreadToOutputRecord" {
         $text | Should -Match "\(src/range\.ts\) 37-52"
 
         $json = Format-UnresolvedThreadsAsJson -Records @($record)
-        $parsed = @($json | ConvertFrom-Json -Depth 8)
+        $parsed = @($json | ConvertFrom-JsonCompat -Depth 8)
         $parsed[0].lineStart | Should -Be 37
         $parsed[0].lineEnd | Should -Be 52
     }
@@ -1140,7 +1141,7 @@ Describe "Format-UnresolvedThreadsAsJson" {
         $json = Format-UnresolvedThreadsAsJson -Records $records
         $json | Should -Match '^\s*\['
 
-        $parsed = @($json | ConvertFrom-Json -Depth 8)
+        $parsed = @($json | ConvertFrom-JsonCompat -Depth 8)
         $parsed.Count | Should -Be 1
         $propertyNames = @($parsed[0].PSObject.Properties.Name)
 

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -292,48 +292,83 @@ Describe "Get-HeaderValue" {
         (Get-HeaderValue -Headers $headers -Key "X-RateLimit-Reset") | Should -BeNullOrEmpty
     }
 
-    It "returns all values from HttpHeaders via TryGetValues" {
-        $response = [System.Net.Http.HttpResponseMessage]::new()
-        try {
-            $response.Headers.Add("X-OAuth-Scopes", "repo")
-            $response.Headers.Add("X-OAuth-Scopes", "read:org")
-
-            $values = @(Get-HeaderValues -Headers $response.Headers -Key "X-OAuth-Scopes")
-            $values.Count | Should -Be 2
-            $values[0] | Should -Be "repo"
-            $values[1] | Should -Be "read:org"
-        }
-        finally {
-            $response.Dispose()
-        }
-    }
-
-    It "reads HttpHeaders values regardless of key casing" {
-        $response = [System.Net.Http.HttpResponseMessage]::new()
-        try {
-            $response.Headers.Add("X-OAuth-Scopes", "repo")
-
-            $values = @(Get-HeaderValues -Headers $response.Headers -Key "x-oauth-scopes")
-            $values.Count | Should -Be 1
-            $values[0] | Should -Be "repo"
-        }
-        finally {
-            $response.Dispose()
-        }
-    }
-
     It "normalizes array-valued hashtable entries to first scalar for Get-HeaderValue" {
         $headers = @{ "X-RateLimit-Reset" = @("123", "456") }
         (Get-HeaderValue -Headers $headers -Key "X-RateLimit-Reset") | Should -Be "123"
     }
+}
 
-    It "returns all array-valued hashtable entries for Get-HeaderValues" {
-        $headers = @{ "X-OAuth-Scopes" = @("repo", "read:org") }
-        $values = @(Get-HeaderValues -Headers $headers -Key "X-OAuth-Scopes")
+Describe "Get-HeaderValues" {
+    BeforeAll {
+        # System.Net.Http is auto-loaded on PowerShell 7+ but NOT on Windows PowerShell 5.1,
+        # where [System.Net.Http.HttpResponseMessage] would otherwise fail to resolve ("Unable
+        # to find type"). Load it explicitly so the real-HttpHeaders provider exercises
+        # production's TryGetValues branch on both editions.
+        Add-Type -AssemblyName System.Net.Http -ErrorAction SilentlyContinue
 
-        $values.Count | Should -Be 2
-        $values[0] | Should -Be "repo"
-        $values[1] | Should -Be "read:org"
+        function New-HeaderProvider {
+            # Builds a headers object of the requested backing kind. Returns the headers plus
+            # an optional disposable owner so HttpResponseMessage (whose Headers is a live view)
+            # can be released after the lookup.
+            param(
+                [Parameter(Mandatory = $true)]
+                [ValidateSet("HttpHeaders", "Hashtable", "GenericDictionary")]
+                [string]$Backing,
+
+                [Parameter(Mandatory = $true)]
+                [hashtable]$Entries
+            )
+
+            switch ($Backing) {
+                "HttpHeaders" {
+                    $response = [System.Net.Http.HttpResponseMessage]::new()
+                    foreach ($key in $Entries.Keys) {
+                        foreach ($value in @($Entries[$key])) {
+                            $response.Headers.Add($key, $value)
+                        }
+                    }
+                    return [pscustomobject]@{ Headers = $response.Headers; Disposable = $response }
+                }
+                "Hashtable" {
+                    return [pscustomobject]@{ Headers = $Entries; Disposable = $null }
+                }
+                "GenericDictionary" {
+                    $dictionary = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                    foreach ($key in $Entries.Keys) {
+                        $dictionary[$key] = [string]@($Entries[$key])[0]
+                    }
+                    return [pscustomobject]@{ Headers = $dictionary; Disposable = $null }
+                }
+            }
+        }
+    }
+
+    # Data-driven across every header backing production must accept: real HttpHeaders (via the
+    # TryGetValues branch), plain hashtables, and case-insensitive generic dictionaries (both
+    # via the ContainsKey branch). Adding a backing here adds a row, not a copy of the body.
+    It "reads <Case>" -ForEach @(
+        @{ Case = "multiple values from real HttpHeaders via TryGetValues"; Backing = "HttpHeaders";       Entries = @{ "X-OAuth-Scopes" = @("repo", "read:org") }; LookupKey = "X-OAuth-Scopes"; Expected = @("repo", "read:org") }
+        @{ Case = "real HttpHeaders regardless of key casing";              Backing = "HttpHeaders";       Entries = @{ "X-OAuth-Scopes" = @("repo") };             LookupKey = "x-oauth-scopes"; Expected = @("repo") }
+        @{ Case = "array-valued hashtable entries";                         Backing = "Hashtable";         Entries = @{ "X-OAuth-Scopes" = @("repo", "read:org") }; LookupKey = "X-OAuth-Scopes"; Expected = @("repo", "read:org") }
+        @{ Case = "case-insensitive generic dictionary entries";            Backing = "GenericDictionary"; Entries = @{ "X-OAuth-Scopes" = "repo" };                LookupKey = "x-oauth-scopes"; Expected = @("repo") }
+    ) {
+        param($Backing, $Entries, $LookupKey, $Expected)
+
+        if ($Backing -eq "HttpHeaders" -and -not ([System.Management.Automation.PSTypeName]'System.Net.Http.HttpResponseMessage').Type) {
+            Set-ItResult -Skipped -Because "System.Net.Http could not be loaded on this runner."
+            return
+        }
+
+        $provider = New-HeaderProvider -Backing $Backing -Entries $Entries
+        try {
+            $values = @(Get-HeaderValues -Headers $provider.Headers -Key $LookupKey)
+            ($values -join '|') | Should -BeExactly ($Expected -join '|') -Because "Get-HeaderValues should return the configured values for the $Backing backing."
+        }
+        finally {
+            if ($null -ne $provider.Disposable) {
+                $provider.Disposable.Dispose()
+            }
+        }
     }
 }
 
@@ -479,12 +514,12 @@ Describe "Get-ClipboardCommandPriority" {
 Describe "Copy-ToClipboard" {
     It "copies text using Set-Clipboard when available" {
         Mock Get-ClipboardCommandPriority { @("Set-Clipboard") }
-        Mock Set-Clipboard { }
+        Mock Set-ClipboardValue { }
 
         $copied = Copy-ToClipboard -Text "copy me"
 
         $copied | Should -BeTrue
-        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $Value -eq "copy me" }
+        Assert-MockCalled Set-ClipboardValue -Times 1 -Scope It -ParameterFilter { $Value -eq "copy me" }
     }
 
     It "returns false and warns when clipboard command is unavailable" {
@@ -505,7 +540,7 @@ Describe "Copy-ToClipboard" {
         $secret = "ghp_" + ("a" * 36)
         $script:lastWarningMessage = $null
         Mock Get-ClipboardCommandPriority { @("Set-Clipboard") }
-        Mock Set-Clipboard { throw "copy failure token=$secret" }
+        Mock Set-ClipboardValue { throw "copy failure token=$secret" }
         Mock Write-Warning {
             param($Message)
             $script:lastWarningMessage = $Message
@@ -522,7 +557,7 @@ Describe "Copy-ToClipboard" {
     It "falls back to Set-Clipboard when OSC52 attempt fails" {
         $script:clipboardAttemptOrder = @()
         Mock Get-ClipboardCommandPriority { @("Set-Clipboard-AsOSC52", "Set-Clipboard") }
-        Mock Set-Clipboard {
+        Mock Set-ClipboardValue {
             param(
                 [string]$Value,
                 [switch]$AsOSC52
@@ -540,19 +575,19 @@ Describe "Copy-ToClipboard" {
 
         $copied | Should -BeTrue
         (($script:clipboardAttemptOrder) -join ",") | Should -Be "Set-Clipboard-AsOSC52,Set-Clipboard" -Because "clipboard fallback should preserve OSC52-first attempt order and then recover with plain Set-Clipboard"
-        Assert-MockCalled Set-Clipboard -Times 2 -Scope It
-        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent }
-        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { -not $AsOSC52.IsPresent }
+        Assert-MockCalled Set-ClipboardValue -Times 2 -Scope It
+        Assert-MockCalled Set-ClipboardValue -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent }
+        Assert-MockCalled Set-ClipboardValue -Times 1 -Scope It -ParameterFilter { -not $AsOSC52.IsPresent }
     }
 
     It "uses Set-Clipboard -AsOSC52 when OSC52 strategy is selected" {
         Mock Get-ClipboardCommandPriority { @("Set-Clipboard-AsOSC52") }
-        Mock Set-Clipboard { }
+        Mock Set-ClipboardValue { }
 
         $copied = Copy-ToClipboard -Text "copy me"
 
         $copied | Should -BeTrue
-        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent -and $Value -eq "copy me" }
+        Assert-MockCalled Set-ClipboardValue -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent -and $Value -eq "copy me" }
     }
 
     It "falls back across native clipboard tools in priority order" {
@@ -611,6 +646,36 @@ Describe "Copy-ToClipboard" {
             Remove-Item -Path Function:xclip -ErrorAction SilentlyContinue
             Remove-Item -Path Function:xsel -ErrorAction SilentlyContinue
         }
+    }
+}
+
+Describe "Set-ClipboardValue" {
+    # The seam exists so Copy-ToClipboard's clipboard tests can mock a command with an
+    # edition-stable parameter set; these tests assert the seam itself routes to Set-Clipboard
+    # correctly (the branch selection that Copy-ToClipboard's mocks otherwise stub out).
+    It "calls Set-Clipboard without -AsOSC52 by default" {
+        Mock Set-Clipboard { }
+
+        Set-ClipboardValue -Value "plain copy"
+
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { -not $AsOSC52.IsPresent -and $Value -eq "plain copy" }
+    }
+
+    It "routes -AsOSC52 through to Set-Clipboard when the parameter exists on this edition" {
+        $setClipboard = Get-Command Set-Clipboard -ErrorAction SilentlyContinue
+        if ($null -eq $setClipboard -or -not $setClipboard.Parameters.ContainsKey('AsOSC52')) {
+            # On Windows PowerShell 5.1 Set-Clipboard has no -AsOSC52, and production never
+            # selects the OSC52 strategy there (Get-ClipboardCommandPriority gates on the same
+            # capability check), so the branch is unreachable and not worth a brittle shim.
+            Set-ItResult -Skipped -Because "Set-Clipboard -AsOSC52 is unavailable on this edition (Windows PowerShell 5.1)."
+            return
+        }
+
+        Mock Set-Clipboard { }
+
+        Set-ClipboardValue -Value "osc52 copy" -AsOSC52
+
+        Assert-MockCalled Set-Clipboard -Times 1 -Scope It -ParameterFilter { $AsOSC52.IsPresent -and $Value -eq "osc52 copy" }
     }
 }
 
@@ -1731,7 +1796,7 @@ Describe "Get-UnresolvedReviewThreads" {
             }
         }
 
-        $records = Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 100 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30))
+        $records = @(Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 100 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)))
 
         $records.Count | Should -Be 2
         ($records | Select-Object -ExpandProperty threadId) | Should -Contain "T1"
@@ -1923,7 +1988,7 @@ Describe "Get-UnresolvedReviewThreads" {
             }
         }
 
-        $records = Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30))
+        $records = @(Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)))
         $records.Count | Should -Be 1
         $records[0].topLevelComment.Length | Should -Be 600
         $records[0].latestReplySummary.Length | Should -Be 400
@@ -1950,7 +2015,7 @@ Describe "Get-UnresolvedReviewThreads" {
             }
         }
 
-        $records = Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)) -Truncate
+        $records = @(Get-UnresolvedReviewThreads -Owner "org" -Repo "repo" -PrNumber 10 -Endpoint "https://api.github.com/graphql" -Headers @{} -GitHubHost "github.com" -PerPage 100 -MaxPages 1 -OverallDeadlineUtc ([datetime]::UtcNow.AddSeconds(30)) -Truncate)
         $records.Count | Should -Be 1
         $records[0].topLevelComment | Should -Match "\[\.\.\.\]$"
         $records[0].latestReplySummary | Should -Match "\[\.\.\.\]$"

--- a/Tests/Utils/CompatibilityConventions.Tests.ps1
+++ b/Tests/Utils/CompatibilityConventions.Tests.ps1
@@ -1,0 +1,110 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    $script:helperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1"
+    $script:gatePath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1"
+    $script:allowlistPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/compatibility-allowlist.psd1"
+}
+
+Describe "Cross-version compatibility infrastructure" {
+    It "ships the keystone compatibility helper, gate, and allowlist" {
+        Test-Path -LiteralPath $script:helperPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $script:gatePath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $script:allowlistPath -PathType Leaf | Should -BeTrue
+    }
+
+    It "exposes the documented portable helper functions" {
+        $content = Get-Content -LiteralPath $script:helperPath -Raw
+        foreach ($fn in @(
+                'Test-IsWindowsPlatform', 'Test-IsMacOSPlatform', 'Test-IsLinuxPlatform',
+                'Get-RelativePathCompat', 'ConvertTo-JsonArrayCompat', 'ConvertFrom-JsonCompat')) {
+            $content | Should -Match ("function\s+" + [regex]::Escape($fn) + "\b")
+        }
+    }
+
+    It "reads OS automatic variables only by name (never as a bare reference) in the helper" {
+        # The keystone helper must access $IsWindows/$IsMacOS/$IsLinux via Get-Variable so
+        # it is itself safe under StrictMode on Windows PowerShell 5.1. Use the AST so
+        # comment mentions of the variable names do not count.
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:helperPath, [ref]$null, [ref]$parseErrors)
+        $bareReferences = @($ast.FindAll({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                    @('IsWindows', 'IsMacOS', 'IsLinux') -contains $node.VariablePath.UserPath
+                }, $true))
+        $bareReferences.Count | Should -Be 0
+    }
+
+    It "never allowlists a real PowerShell cmdlet whose parameters differ across editions" {
+        $allowlist = Import-PowerShellDataFile -LiteralPath $script:allowlistPath
+        $allEntries = @($allowlist.ExternalExecutables) + @($allowlist.ModuleCommands)
+        $forbidden = @('ConvertTo-Json', 'ConvertFrom-Json', 'New-Item', 'Get-Content', 'Set-Content', 'Set-Clipboard', 'Set-PSReadLineOption')
+        foreach ($command in $forbidden) {
+            $allEntries | Should -Not -Contain $command
+        }
+    }
+}
+
+Describe "Cross-version compatibility - automatic variable scan (dependency-free)" {
+    It "has no bare 5.1-undefined automatic variable references in repository PowerShell scripts" {
+        # Mirrors the gate's AST scan but needs no PSScriptAnalyzer, so it runs on every
+        # lane (including the Windows PowerShell 5.1 test lane). $IsWindows/$IsMacOS/$IsLinux
+        # do not exist on Desktop edition and throw under StrictMode; $PSStyle is 7.2+.
+        $forbidden = @('IsWindows', 'IsMacOS', 'IsLinux', 'IsCoreCLR', 'PSStyle')
+        $scanRoots = @('Scripts', 'Config', 'Tests') |
+            ForEach-Object { Join-Path -Path $script:repoRoot -ChildPath $_ } |
+            Where-Object { Test-Path -LiteralPath $_ -PathType Container }
+        $files = @(Get-ChildItem -Path $scanRoots -Recurse -File -Include *.ps1, *.psm1)
+
+        $violations = New-Object System.Collections.Generic.List[string]
+        foreach ($file in $files) {
+            if ($file.Name -eq 'CompatibilityHelpers.ps1') {
+                continue
+            }
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$parseErrors)
+            if ($null -eq $ast) {
+                continue
+            }
+            $bare = @($ast.FindAll({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                        @('IsWindows', 'IsMacOS', 'IsLinux', 'IsCoreCLR', 'PSStyle') -contains $node.VariablePath.UserPath
+                    }, $true))
+            foreach ($reference in $bare) {
+                $violations.Add(("{0}:{1} `${2}" -f $file.Name, $reference.Extent.StartLineNumber, $reference.VariablePath.UserPath)) | Out-Null
+            }
+        }
+
+        $violations.Count | Should -Be 0 -Because (
+            "Use the Test-Is*Platform helpers (or Get-Variable) instead of bare automatic variables. Violations: " + ($violations -join '; '))
+    }
+}
+
+Describe "Cross-version compatibility gate (PSScriptAnalyzer)" {
+    It "reports zero cross-version incompatibilities across the repository" {
+        # The full static gate depends on pwsh + PSScriptAnalyzer. When either is unavailable
+        # (for example the runtime-only Windows PowerShell 5.1 test lane) this is covered by
+        # the dedicated powershell-compat-analyzer CI lane instead.
+        if ($null -eq (Get-Command pwsh -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because "pwsh is unavailable; the compat gate is enforced by the powershell-compat-analyzer CI lane."
+            return
+        }
+        $analyzerAvailable = & pwsh -NoProfile -Command "[bool](Get-Module -ListAvailable -Name PSScriptAnalyzer)"
+        if ($analyzerAvailable -ne 'True' -and $analyzerAvailable -ne $true) {
+            Set-ItResult -Skipped -Because "PSScriptAnalyzer is not available; the compat gate is enforced by the powershell-compat-analyzer CI lane."
+            return
+        }
+
+        $gateJson = & pwsh -NoProfile -File $script:gatePath -OutputFormat json
+        $gateResult = ($gateJson | Out-String) | ConvertFrom-Json
+        $messages = @($gateResult.findings | ForEach-Object { "$($_.file):$($_.line) [$($_.ruleName)]" })
+        $gateResult.findingCount | Should -Be 0 -Because (
+            "All PowerShell scripts must run on Windows PowerShell 5.1 and PowerShell 7+. Remaining findings: " + ($messages -join '; '))
+        # Sanity check that the allowlist is actually engaged (external exes / Pester DSL).
+        $gateResult.allowedFindingCount | Should -BeGreaterThan 0
+    }
+}

--- a/Tests/Utils/CompatibilityConventions.Tests.ps1
+++ b/Tests/Utils/CompatibilityConventions.Tests.ps1
@@ -108,3 +108,132 @@ Describe "Cross-version compatibility gate (PSScriptAnalyzer)" {
         $gateResult.allowedFindingCount | Should -BeGreaterThan 0
     }
 }
+
+Describe "Cross-version compatibility - Core-only .NET member scan (dependency-free)" {
+    BeforeAll {
+        # Mirrors Get-CoreOnlyMemberViolation in Invoke-CompatibilityChecks.ps1 so the invariant
+        # is ALSO enforced on the Windows PowerShell 5.1 runtime lane (no PSScriptAnalyzer). A
+        # deliberately runtime-guarded native access opts out with an inline
+        # '# compat-core-member-ok' marker; there is no whole-file allowlist.
+        $script:coreOnlyMemberRules = @{
+            'ArgumentList'      = @{ RequireInvocation = $false; MinArgumentCount = 0 }
+            'ResolveLinkTarget' = @{ RequireInvocation = $true; MinArgumentCount = 0 }
+            'LinkTarget'        = @{ RequireInvocation = $false; MinArgumentCount = 0 }
+            'Kill'              = @{ RequireInvocation = $true; MinArgumentCount = 1 }
+        }
+
+        function Get-CoreOnlyMemberViolationFromAst {
+            # Pure detection over a parsed AST + its source lines, so the same logic backs both
+            # the file scan and the string-based positive test (without writing a temp file).
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [string[]]$Lines,
+                [hashtable]$Rules
+            )
+
+            $found = New-Object System.Collections.Generic.List[object]
+            if ($null -eq $Ast) {
+                return , @($found.ToArray())
+            }
+
+            $memberAsts = @($Ast.FindAll({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.MemberExpressionAst]
+                    }, $true))
+            foreach ($memberAst in $memberAsts) {
+                if (-not ($memberAst.Member -is [System.Management.Automation.Language.StringConstantExpressionAst])) {
+                    continue
+                }
+                $name = $memberAst.Member.Value
+                if (-not $Rules.ContainsKey($name)) {
+                    continue
+                }
+                $rule = $Rules[$name]
+                $isInvocation = ($memberAst -is [System.Management.Automation.Language.InvokeMemberExpressionAst])
+                if ($rule.RequireInvocation -and -not $isInvocation) {
+                    continue
+                }
+                if ($rule.MinArgumentCount -gt 0) {
+                    if (-not $isInvocation) {
+                        continue
+                    }
+                    $argCount = 0
+                    if ($null -ne $memberAst.Arguments) {
+                        $argCount = @($memberAst.Arguments).Count
+                    }
+                    if ($argCount -lt $rule.MinArgumentCount) {
+                        continue
+                    }
+                }
+                # Scan every line the member expression spans for the opt-out marker (mirrors
+                # the gate's Get-CoreOnlyMemberViolation).
+                $isMarked = $false
+                for ($markerLine = $memberAst.Extent.StartLineNumber; $markerLine -le $memberAst.Extent.EndLineNumber; $markerLine++) {
+                    if ($markerLine -ge 1 -and $markerLine -le $Lines.Length -and $Lines[$markerLine - 1].Contains('compat-core-member-ok')) {
+                        $isMarked = $true
+                        break
+                    }
+                }
+                if ($isMarked) {
+                    continue
+                }
+                $found.Add([pscustomobject]@{ Name = $name; Line = $memberAst.Extent.StartLineNumber }) | Out-Null
+            }
+            return , @($found.ToArray())
+        }
+    }
+
+    It "has no unguarded .NET Core-only member access in production scripts" {
+        $scriptsRoot = Join-Path -Path $script:repoRoot -ChildPath 'Scripts'
+        $files = @(Get-ChildItem -Path $scriptsRoot -Recurse -File -Include *.ps1, *.psm1)
+
+        $violations = New-Object System.Collections.Generic.List[string]
+        foreach ($file in $files) {
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$null)
+            $lines = [System.IO.File]::ReadAllLines($file.FullName)
+            foreach ($v in (Get-CoreOnlyMemberViolationFromAst -Ast $ast -Lines $lines -Rules $script:coreOnlyMemberRules)) {
+                $violations.Add(("{0}:{1} .{2}" -f $file.Name, $v.Line, $v.Name)) | Out-Null
+            }
+        }
+
+        $violations.Count | Should -Be 0 -Because (
+            "ProcessStartInfo.ArgumentList / FileSystemInfo.ResolveLinkTarget / .LinkTarget / Process.Kill([bool]) throw on Windows PowerShell 5.1; route them through the CompatibilityHelpers shims (Set-PortableProcessArguments / Get-PortableLinkTarget / Stop-ProcessTreePortably) or annotate a deliberately-guarded access with '# compat-core-member-ok'. Violations: " + ($violations -join '; '))
+    }
+
+    It "flags unguarded Core-only access (incl. Kill([bool]) overload), honors the opt-out marker, and ignores look-alikes" {
+        # Parse from a string (no temp file) so the detection logic is verified directly.
+        $sample = @'
+param([string[]]$ArgumentList)
+$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$startInfo.ArgumentList.Add("x")
+$probe = [System.Diagnostics.ProcessStartInfo].GetProperty('ArgumentList')
+$item.ResolveLinkTarget($true)
+$count = $ArgumentList.Count
+$process.Kill()
+$process.Kill($true)
+$guarded.ResolveLinkTarget($true) # compat-core-member-ok
+'@
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($sample, [ref]$null, [ref]$null)
+        $lines = $sample -split "`r?`n"
+        # Get-CoreOnlyMemberViolationFromAst comma-wraps its return for empty-safety, so the
+        # call site must NOT wrap with @() (that would nest the array). See .llm/context.md
+        # "PowerShell Empty Array Return Safety".
+        $flagged = Get-CoreOnlyMemberViolationFromAst -Ast $ast -Lines $lines -Rules $script:coreOnlyMemberRules
+        $names = @($flagged | ForEach-Object { $_.Name })
+
+        # Caught: unguarded $startInfo.ArgumentList, unguarded $item.ResolveLinkTarget, and the
+        # Core-only Process.Kill($true) OVERLOAD.
+        ($names -contains 'ArgumentList') | Should -BeTrue
+        ($names -contains 'ResolveLinkTarget') | Should -BeTrue
+        ($names -contains 'Kill') | Should -BeTrue
+
+        # Kill() (no argument) is present on both editions and must NOT be flagged; only the
+        # Kill($true) overload is. So exactly one 'Kill' violation.
+        (@($names | Where-Object { $_ -eq 'Kill' }).Count) | Should -Be 1
+        # The marked $guarded.ResolveLinkTarget is exempt, so exactly one 'ResolveLinkTarget'.
+        (@($names | Where-Object { $_ -eq 'ResolveLinkTarget' }).Count) | Should -Be 1
+        # Look-alikes ($ArgumentList param/Count, GetProperty('ArgumentList') string arg) excluded.
+        (@($names | Where-Object { $_ -eq 'ArgumentList' }).Count) | Should -Be 1
+        $flagged.Count | Should -Be 3
+    }
+}

--- a/Tests/Utils/CompatibilityHelpers.Tests.ps1
+++ b/Tests/Utils/CompatibilityHelpers.Tests.ps1
@@ -2,6 +2,16 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 BeforeAll {
+    function Resolve-CanonicalTempRoot {
+        param([string]$Path)
+
+        # Match FileInfo.FullName canonicalization so path comparisons are stable under
+        # symlink aliases (for example /var vs /private/var on macOS); see .llm/context.md
+        # "Test Temp Directory Canonicalization".
+        $resolvedItem = Get-Item -LiteralPath $Path -ErrorAction Stop
+        return $resolvedItem.FullName
+    }
+
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
     $script:helperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1"
     . $script:helperPath
@@ -159,5 +169,250 @@ Describe "ConvertFrom-JsonCompat" {
 
     It "honors -Depth without throwing" {
         { '{"a":{"b":{"c":1}}}' | ConvertFrom-JsonCompat -Depth 5 } | Should -Not -Throw
+    }
+}
+
+Describe "ConvertTo-ProcessArgumentString" {
+    # Expected strings are computed by hand from the .NET Core PasteArguments algorithm so the
+    # exact rendered command line is documented and locked. The round-trip test below proves
+    # the strings actually parse back to the original argument vector.
+    It "renders <Case> exactly" -ForEach @(
+        @{ Case = "no arguments";              Arguments = @();                       Expected = "" }
+        @{ Case = "single empty argument";     Arguments = @("");                     Expected = '""' }
+        @{ Case = "simple token";              Arguments = @("simple");               Expected = "simple" }
+        @{ Case = "two tokens";                Arguments = @("a", "b");               Expected = "a b" }
+        @{ Case = "embedded space";            Arguments = @("has space");            Expected = '"has space"' }
+        @{ Case = "literal backslashes";       Arguments = @("C:\path\file");         Expected = "C:\path\file" }
+        @{ Case = "trailing backslash, no ws"; Arguments = @("trailing\");            Expected = "trailing\" }
+        @{ Case = "trailing backslash, ws";    Arguments = @("with space\");          Expected = '"with space\\"' }
+        @{ Case = "embedded quote";            Arguments = @('quote"inside');         Expected = '"quote\"inside"' }
+        @{ Case = "empty then value";          Arguments = @("", "value");            Expected = '"" value' }
+    ) {
+        param($Arguments, $Expected)
+        (ConvertTo-ProcessArgumentString -ArgumentList $Arguments) | Should -BeExactly $Expected
+    }
+
+    It "treats a null argument list as empty" {
+        (ConvertTo-ProcessArgumentString -ArgumentList $null) | Should -BeExactly ""
+    }
+}
+
+Describe "Set-PortableProcessArguments" {
+    BeforeAll {
+        $script:hostPwsh = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+        # A tiny echo script: emit each received argument on its own line behind a marker so
+        # empty arguments and surrounding whitespace survive the round-trip unambiguously.
+        $script:echoScript = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("compat-echo-{0}.ps1" -f ([System.Guid]::NewGuid().ToString("N")))
+        Set-Content -LiteralPath $script:echoScript -Value '$args | ForEach-Object { [Console]::Out.WriteLine("ARG:" + $_) }' -Encoding utf8
+
+        function Invoke-ArgumentRoundTrip {
+            param(
+                [string[]]$Arguments,
+                [switch]$ForceFallback
+            )
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $script:hostPwsh
+            $startInfo.UseShellExecute = $false
+            $startInfo.RedirectStandardOutput = $true
+            $launchArguments = @("-NoLogo", "-NoProfile", "-File", $script:echoScript) + $Arguments
+            Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList $launchArguments -ForceFallback:$ForceFallback
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $startInfo
+            try {
+                [void]$process.Start()
+                $stdout = $process.StandardOutput.ReadToEnd()
+                [void]$process.WaitForExit(30000)
+            }
+            finally {
+                $process.Dispose()
+            }
+
+            $observed = @(($stdout -split "`r?`n") |
+                    Where-Object { $_.StartsWith("ARG:") } |
+                    ForEach-Object { $_.Substring(4) })
+            return , $observed
+        }
+    }
+
+    AfterAll {
+        if ($script:echoScript -and (Test-Path -LiteralPath $script:echoScript)) {
+            Remove-Item -LiteralPath $script:echoScript -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "round-trips <Case> via the native ArgumentList path" -ForEach @(
+        @{ Case = "plain";            Arguments = @("plain") }
+        @{ Case = "embedded space";   Arguments = @("with space") }
+        @{ Case = "two tokens";       Arguments = @("two", "args") }
+        @{ Case = "embedded quote";   Arguments = @('embedded"quote') }
+        @{ Case = "trailing slash";   Arguments = @("trailing\") }
+        @{ Case = "backslash run";    Arguments = @("back\\slash\\\\path") }
+        @{ Case = "quote and space";  Arguments = @('quote" and space') }
+        @{ Case = "empty argument";   Arguments = @("alpha", "", "omega") }
+    ) {
+        param($Arguments)
+        (Invoke-ArgumentRoundTrip -Arguments $Arguments) | Should -Be $Arguments
+    }
+
+    It "round-trips <Case> via the Windows PowerShell 5.1 (.Arguments string) fallback" -ForEach @(
+        @{ Case = "plain";            Arguments = @("plain") }
+        @{ Case = "embedded space";   Arguments = @("with space") }
+        @{ Case = "two tokens";       Arguments = @("two", "args") }
+        @{ Case = "embedded quote";   Arguments = @('embedded"quote') }
+        @{ Case = "trailing slash";   Arguments = @("trailing\") }
+        @{ Case = "backslash run";    Arguments = @("back\\slash\\\\path") }
+        @{ Case = "quote and space";  Arguments = @('quote" and space') }
+        @{ Case = "empty argument";   Arguments = @("alpha", "", "omega") }
+    ) {
+        param($Arguments)
+        # The forced fallback proves ConvertTo-ProcessArgumentString escapes exactly as the
+        # native ArgumentList does: both paths must yield identical child argv.
+        (Invoke-ArgumentRoundTrip -Arguments $Arguments -ForceFallback) | Should -Be $Arguments
+    }
+
+    It "selects the native ArgumentList collection on PowerShell 7+" {
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            Set-ItResult -Skipped -Because "ArgumentList is only present on PowerShell 7+ / .NET Core."
+            return
+        }
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList @("alpha", "beta")
+        $startInfo.ArgumentList.Count | Should -Be 2
+        $startInfo.Arguments | Should -BeNullOrEmpty
+    }
+
+    It "writes the escaped string to .Arguments under the forced fallback" {
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList @("a", "b c") -ForceFallback
+        $startInfo.Arguments | Should -BeExactly 'a "b c"'
+    }
+}
+
+Describe "Get-PortableLinkTarget" {
+    BeforeAll {
+        $script:linkRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("compat-link-{0}" -f ([System.Guid]::NewGuid().ToString("N")))
+        New-Item -ItemType Directory -Path $script:linkRoot -Force | Out-Null
+        # Canonicalize so GetFullPath comparisons below are stable under macOS /var aliasing.
+        $script:linkRoot = Resolve-CanonicalTempRoot -Path $script:linkRoot
+
+        $script:realTarget = Join-Path -Path $script:linkRoot -ChildPath "real"
+        New-Item -ItemType Directory -Path $script:realTarget -Force | Out-Null
+
+        # Symbolic-link creation can require privilege (notably on Windows without Developer
+        # Mode). Probe once and skip the link scenarios cleanly when it is unavailable.
+        $script:directLink = Join-Path -Path $script:linkRoot -ChildPath "direct"
+        $script:chainLink = Join-Path -Path $script:linkRoot -ChildPath "chain"
+        $script:symlinksAvailable = $false
+        try {
+            New-Item -ItemType SymbolicLink -Path $script:directLink -Target $script:realTarget -ErrorAction Stop | Out-Null
+            New-Item -ItemType SymbolicLink -Path $script:chainLink -Target $script:directLink -ErrorAction Stop | Out-Null
+            $script:symlinksAvailable = $true
+        }
+        catch {
+            $script:symlinksAvailable = $false
+        }
+    }
+
+    AfterAll {
+        if ($script:linkRoot -and (Test-Path -LiteralPath $script:linkRoot)) {
+            Remove-Item -LiteralPath $script:linkRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "returns `$null for a non-link directory" {
+        $item = Get-Item -LiteralPath $script:realTarget -Force
+        Get-PortableLinkTarget -Item $item | Should -BeNullOrEmpty
+    }
+
+    It "resolves a direct symbolic link to its final target" {
+        if (-not $script:symlinksAvailable) { Set-ItResult -Skipped -Because "symbolic links are unavailable on this runner"; return }
+        $item = Get-Item -LiteralPath $script:directLink -Force
+        $resolved = Get-PortableLinkTarget -Item $item
+        [System.IO.Path]::GetFullPath($resolved) | Should -Be ([System.IO.Path]::GetFullPath($script:realTarget))
+    }
+
+    It "follows a symbolic-link chain to its final target" {
+        if (-not $script:symlinksAvailable) { Set-ItResult -Skipped -Because "symbolic links are unavailable on this runner"; return }
+        $item = Get-Item -LiteralPath $script:chainLink -Force
+        $resolved = Get-PortableLinkTarget -Item $item
+        [System.IO.Path]::GetFullPath($resolved) | Should -Be ([System.IO.Path]::GetFullPath($script:realTarget))
+    }
+
+    It "matches the native method under the forced 5.1 (ETS) fallback for <Case>" -ForEach @(
+        @{ Case = "direct link" }
+        @{ Case = "chain link" }
+    ) {
+        param($Case)
+        if (-not $script:symlinksAvailable) { Set-ItResult -Skipped -Because "symbolic links are unavailable on this runner"; return }
+
+        $linkPath = if ($Case -eq "direct link") { $script:directLink } else { $script:chainLink }
+        $item = Get-Item -LiteralPath $linkPath -Force
+        $native = Get-PortableLinkTarget -Item $item
+        $fallback = Get-PortableLinkTarget -Item $item -ForceFallback
+        [System.IO.Path]::GetFullPath($fallback) | Should -Be ([System.IO.Path]::GetFullPath($native)) -Because "the 5.1 ETS fallback must resolve to the same final target as the native ResolveLinkTarget."
+    }
+
+    It "terminates (does not loop) on a symbolic-link cycle under the 5.1 fallback" {
+        $cycleA = Join-Path -Path $script:linkRoot -ChildPath "cycle-a"
+        $cycleB = Join-Path -Path $script:linkRoot -ChildPath "cycle-b"
+        $cycleCreated = $false
+        try {
+            # Dangling targets are permitted at creation time on POSIX, forming a 2-node cycle.
+            New-Item -ItemType SymbolicLink -Path $cycleA -Target $cycleB -ErrorAction Stop | Out-Null
+            New-Item -ItemType SymbolicLink -Path $cycleB -Target $cycleA -ErrorAction Stop | Out-Null
+            $cycleCreated = $true
+        }
+        catch {
+            $cycleCreated = $false
+        }
+        if (-not $cycleCreated) { Set-ItResult -Skipped -Because "symbolic-link cycles cannot be created on this runner"; return }
+
+        $item = Get-Item -LiteralPath $cycleA -Force
+        # The visited-target set (plus the MaxDepth bound) must break the cycle rather than hang,
+        # and return $null to match the native ResolveLinkTarget($true) "unresolved" outcome.
+        $cycleResult = $null
+        { $cycleResult = Get-PortableLinkTarget -Item $item -ForceFallback } | Should -Not -Throw
+        $cycleResult | Should -BeNullOrEmpty -Because "a symbolic-link cycle is unresolvable, mirroring native ResolveLinkTarget."
+    }
+}
+
+Describe "Stop-ProcessTreePortably" {
+    BeforeAll {
+        $script:killHostPwsh = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+
+        function Start-LongRunningProcess {
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $script:killHostPwsh
+            $startInfo.UseShellExecute = $false
+            Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList @("-NoLogo", "-NoProfile", "-Command", "Start-Sleep -Seconds 120")
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $startInfo
+            [void]$process.Start()
+            return $process
+        }
+    }
+
+    It "terminates a running process via <Case>" -ForEach @(
+        @{ Case = "the native tree-kill path"; ForceFallback = $false }
+        @{ Case = "the Windows PowerShell 5.1 parameterless-Kill fallback"; ForceFallback = $true }
+    ) {
+        param($ForceFallback)
+
+        $process = Start-LongRunningProcess
+        try {
+            $process.HasExited | Should -BeFalse -Because "the sleep process should still be running before we kill it."
+            Stop-ProcessTreePortably -Process $process -ForceFallback:$ForceFallback
+            $process.WaitForExit(20000) | Should -BeTrue -Because "the process must be terminated by Stop-ProcessTreePortably."
+            $process.HasExited | Should -BeTrue
+        }
+        finally {
+            if (-not $process.HasExited) {
+                $process.Kill()
+            }
+            $process.Dispose()
+        }
     }
 }

--- a/Tests/Utils/CompatibilityHelpers.Tests.ps1
+++ b/Tests/Utils/CompatibilityHelpers.Tests.ps1
@@ -1,0 +1,163 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    $script:helperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1"
+    . $script:helperPath
+}
+
+Describe "CompatibilityHelpers OS detection" {
+    It "exposes the Test-Is*Platform helpers" {
+        Get-Command Test-IsWindowsPlatform -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        Get-Command Test-IsMacOSPlatform -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        Get-Command Test-IsLinuxPlatform -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It "returns booleans without throwing under StrictMode" {
+        { Test-IsWindowsPlatform } | Should -Not -Throw
+        { Test-IsMacOSPlatform } | Should -Not -Throw
+        { Test-IsLinuxPlatform } | Should -Not -Throw
+        (Test-IsWindowsPlatform) | Should -BeOfType [bool]
+        (Test-IsMacOSPlatform) | Should -BeOfType [bool]
+        (Test-IsLinuxPlatform) | Should -BeOfType [bool]
+    }
+
+    It "identifies exactly one of Windows/macOS/Linux as the current platform" {
+        $trueCount = @((Test-IsWindowsPlatform), (Test-IsMacOSPlatform), (Test-IsLinuxPlatform) | Where-Object { $_ }).Count
+        $trueCount | Should -Be 1
+    }
+
+    It "agrees with the running edition's platform on PowerShell 7+ (read via Get-Variable, 5.1-safe)" {
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            # Read the automatic variables by name so this test itself never references a
+            # 5.1-undefined automatic variable directly.
+            $rawWindows = [bool](Get-Variable -Name IsWindows -ValueOnly -ErrorAction SilentlyContinue)
+            $rawMac = [bool](Get-Variable -Name IsMacOS -ValueOnly -ErrorAction SilentlyContinue)
+            $rawLinux = [bool](Get-Variable -Name IsLinux -ValueOnly -ErrorAction SilentlyContinue)
+            (Test-IsWindowsPlatform) | Should -Be $rawWindows
+            (Test-IsMacOSPlatform) | Should -Be $rawMac
+            (Test-IsLinuxPlatform) | Should -Be $rawLinux
+        } else {
+            # Desktop edition (Windows PowerShell 5.1) only runs on Windows.
+            (Test-IsWindowsPlatform) | Should -BeTrue
+            (Test-IsMacOSPlatform) | Should -BeFalse
+            (Test-IsLinuxPlatform) | Should -BeFalse
+        }
+    }
+}
+
+Describe "Get-RelativePathCompat" {
+    # Expected values use '/' separators; the actual result is normalized to '/' so the
+    # contract is asserted identically on Windows ('\') and Unix ('/'). These expectations
+    # are hardcoded rather than compared to [System.IO.Path]::GetRelativePath because that
+    # native method does not exist on Windows PowerShell 5.1.
+    It "computes the relative path for <Case>" -ForEach @(
+        @{ Case = "child";            Base = "/a/b";       Target = "/a/b/c";                  Expected = "c" }
+        @{ Case = "deep child";       Base = "/home/user"; Target = "/home/user/docs/file.txt"; Expected = "docs/file.txt" }
+        @{ Case = "parent";           Base = "/a/b/c";     Target = "/a/b";                    Expected = ".." }
+        @{ Case = "grandparent";      Base = "/a/b/c/d";   Target = "/a/b";                    Expected = "../.." }
+        @{ Case = "sibling";          Base = "/a/b";       Target = "/a/x/y";                  Expected = "../x/y" }
+        @{ Case = "identical";        Base = "/a/b/c";     Target = "/a/b/c";                  Expected = "." }
+        @{ Case = "identical w/slash"; Base = "/a/b/c";    Target = "/a/b/c/";                 Expected = "." }
+        @{ Case = "spaces";           Base = "/a b/c";     Target = "/a b/c/d e";              Expected = "d e" }
+        @{ Case = "from root";        Base = "/";          Target = "/etc/hosts";              Expected = "etc/hosts" }
+    ) {
+        $actual = (Get-RelativePathCompat -BasePath $Base -TargetPath $Target) -replace '\\', '/'
+        $actual | Should -BeExactly $Expected
+    }
+
+    It "the .NET Framework fallback computes the same relative path for <Case>" -ForEach @(
+        @{ Case = "child";       Base = "/a/b";     Target = "/a/b/c"; Expected = "c" }
+        @{ Case = "parent";      Base = "/a/b/c";   Target = "/a/b";   Expected = ".." }
+        @{ Case = "grandparent"; Base = "/a/b/c/d"; Target = "/a/b";   Expected = "../.." }
+        @{ Case = "sibling";     Base = "/a/b";     Target = "/a/x/y"; Expected = "../x/y" }
+        @{ Case = "identical";   Base = "/a/b/c";   Target = "/a/b/c"; Expected = "." }
+        @{ Case = "from root";   Base = "/";        Target = "/etc/hosts"; Expected = "etc/hosts" }
+    ) {
+        $actual = (Get-RelativePathCompat -BasePath $Base -TargetPath $Target -ForceFallback) -replace '\\', '/'
+        $actual | Should -BeExactly $Expected
+    }
+
+    It "the fallback matches the native method exactly when native is available (differential)" {
+        # When the native [System.IO.Path]::GetRelativePath exists (PowerShell 7+/.NET 5+),
+        # the -ForceFallback path must produce byte-identical results to it. The native
+        # method is invoked via reflection so this comparison itself stays 5.1-safe (a raw
+        # [System.IO.Path]::GetRelativePath token would be a 5.1 incompatibility).
+        $nativeMethod = [System.IO.Path].GetMethod('GetRelativePath', [type[]]@([string], [string]))
+        if ($null -eq $nativeMethod) {
+            Set-ItResult -Skipped -Because "native GetRelativePath is unavailable (Windows PowerShell 5.1); the fallback is the only implementation."
+            return
+        }
+        $cases = @(
+            @('/a/b', '/a/b/c'), @('/a/b/c', '/a/b'), @('/a/b/c/d', '/a/b'),
+            @('/a/b', '/a/x/y'), @('/a/b/c', '/a/b/c'), @('/a/b/c', '/a/b/c/'),
+            @('/home/user', '/home/user/docs/file.txt'), @('/a b/c', '/a b/c/d e'),
+            @('/', '/etc/hosts'), @('/a', '/a')
+        )
+        foreach ($case in $cases) {
+            $native = $nativeMethod.Invoke($null, @([string]$case[0], [string]$case[1]))
+            $fallback = Get-RelativePathCompat -BasePath $case[0] -TargetPath $case[1] -ForceFallback
+            $fallback | Should -BeExactly $native -Because "fallback must match native for base='$($case[0])' target='$($case[1])'"
+        }
+    }
+}
+
+Describe "ConvertTo-JsonArrayCompat" {
+    It "emits a JSON array for a single object" {
+        $json = ConvertTo-JsonArrayCompat -InputObject ([pscustomobject]@{ name = "one" }) -Compress
+        $json | Should -BeExactly '[{"name":"one"}]'
+    }
+
+    It "emits an empty JSON array for an empty collection" {
+        $json = ConvertTo-JsonArrayCompat -InputObject @() -Compress
+        $json | Should -BeExactly '[]'
+    }
+
+    It "emits a JSON array for multiple objects" {
+        $json = ConvertTo-JsonArrayCompat -InputObject @([pscustomobject]@{ n = 1 }, [pscustomobject]@{ n = 2 }) -Compress
+        $json | Should -BeExactly '[{"n":1},{"n":2}]'
+    }
+
+    It "accepts pipeline input and preserves array shape" {
+        $json = @([pscustomobject]@{ n = 1 }) | ConvertTo-JsonArrayCompat -Compress
+        $json | Should -BeExactly '[{"n":1}]'
+    }
+
+    It "always produces a leading bracket (array shape) regardless of count" {
+        foreach ($count in 0, 1, 2, 5) {
+            $items = @(1..$count | ForEach-Object { [pscustomobject]@{ i = $_ } })
+            $json = ConvertTo-JsonArrayCompat -InputObject $items -Compress
+            $json.TrimStart()[0] | Should -BeExactly '['
+        }
+    }
+}
+
+Describe "ConvertFrom-JsonCompat" {
+    It "parses an object" {
+        $obj = '{"a":1,"b":"two"}' | ConvertFrom-JsonCompat
+        $obj.a | Should -Be 1
+        $obj.b | Should -Be "two"
+    }
+
+    It "preserves top-level array shape with -NoEnumerate" {
+        $arr = '[1,2,3]' | ConvertFrom-JsonCompat -NoEnumerate
+        $arr.Count | Should -Be 3
+    }
+
+    It "preserves a single-element top-level array with -NoEnumerate" {
+        $arr = '[42]' | ConvertFrom-JsonCompat -NoEnumerate
+        , $arr | Should -BeOfType [System.Array]
+        $arr.Count | Should -Be 1
+        $arr[0] | Should -Be 42
+    }
+
+    It "returns a top-level object as-is with -NoEnumerate" {
+        $obj = '{"a":1}' | ConvertFrom-JsonCompat -NoEnumerate
+        $obj.a | Should -Be 1
+    }
+
+    It "honors -Depth without throwing" {
+        { '{"a":{"b":{"c":1}}}' | ConvertFrom-JsonCompat -Depth 5 } | Should -Not -Throw
+    }
+}

--- a/Tests/Utils/Invoke-NativeQualityChecks.Tests.ps1
+++ b/Tests/Utils/Invoke-NativeQualityChecks.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..") -ErrorAction Stop).Path
     $script:nativeQualityScriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Invoke-NativeQualityChecks.ps1"
     . $script:nativeQualityScriptPath -NoInvokeMain
+    . (Join-Path -Path $PSScriptRoot -ChildPath "../../Scripts/Utils/Common/CompatibilityHelpers.ps1")
 }
 
 Describe "Invoke-NativeQualityChecks platform resolution" {
@@ -69,7 +70,7 @@ Describe "Invoke-NativeQualityChecks target scoping" {
     }
 
     It "rejects a case-variant repository-root target on case-sensitive filesystems" {
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             Set-ItResult -Skipped -Because "Ordinal (case-sensitive) boundary rejection only applies on non-Windows filesystems."
             return
         }

--- a/Tests/Utils/Invoke-ShellQualityChecks.Tests.ps1
+++ b/Tests/Utils/Invoke-ShellQualityChecks.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..") -ErrorAction Stop).Path
     $script:shellQualityScriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Invoke-ShellQualityChecks.ps1"
     . $script:shellQualityScriptPath -NoInvokeMain
+    . (Join-Path -Path $PSScriptRoot -ChildPath "../../Scripts/Utils/Common/CompatibilityHelpers.ps1")
 }
 
 Describe "Invoke-ShellQualityChecks platform resolution" {
@@ -149,7 +150,7 @@ Describe "Invoke-ShellQualityChecks archive path safety" {
     }
 
     It "rejects extracted link-like executables before copying" {
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             Set-ItResult -Skipped -Because "Windows symlink creation requires host-specific privileges."
             return
         }

--- a/Tests/Utils/Invoke-WindowsLanguageChecks.Tests.ps1
+++ b/Tests/Utils/Invoke-WindowsLanguageChecks.Tests.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = "Stop"
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
     . (Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1") -NoInvokeMain
+    . (Join-Path -Path $PSScriptRoot -ChildPath "../../Scripts/Utils/Common/CompatibilityHelpers.ps1")
 }
 
 Describe "Test-OutputLooksLikeUnsupportedAhkSwitch" {
@@ -278,7 +279,7 @@ Describe "Invoke-AutoHotkeyCommand" {
         $originalVerbosePreference = $VerbosePreference
         try {
             $VerbosePreference = "Continue"
-            Write-Verbose "[Invoke-AutoHotkeyCommand diag] Case='$Case' ExitCode=$($result.ExitCode) ExpectedExitCode=$expectedExitCode OutputLines=$outputLineCount IsWindows=$IsWindows diagnostics=$diagnostics"
+            Write-Verbose "[Invoke-AutoHotkeyCommand diag] Case='$Case' ExitCode=$($result.ExitCode) ExpectedExitCode=$expectedExitCode OutputLines=$outputLineCount IsWindows=$(Test-IsWindowsPlatform) diagnostics=$diagnostics"
             Write-Verbose "[Invoke-AutoHotkeyCommand diag] OutputPreview:`n$outputPreview"
         }
         finally {

--- a/Tests/Utils/LlmHarness.Tests.ps1
+++ b/Tests/Utils/LlmHarness.Tests.ps1
@@ -17,6 +17,21 @@ BeforeAll {
 
     . $wrapperHelperPath
 
+    $script:compatibilityHelperPath = Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Utils/Common/CompatibilityHelpers.ps1'
+    if (-not (Test-Path -Path $script:compatibilityHelperPath -PathType Leaf)) {
+        throw "E_CONFIG_ERROR: Compatibility helper file not found at '$script:compatibilityHelperPath'."
+    }
+
+    # Helper: copy the index updater into a temp tree along with the Common helpers it
+    # dot-sources, so the copied script can resolve '../Common/CompatibilityHelpers.ps1'.
+    $script:CopyUpdaterToTemp = {
+        param([string]$TempUpdaterPath)
+        Copy-Item -Path $script:indexUpdaterPath -Destination $TempUpdaterPath -Force
+        $tempCommonDir = Join-Path -Path (Split-Path -Path (Split-Path -Path $TempUpdaterPath -Parent) -Parent) -ChildPath 'Common'
+        [System.IO.Directory]::CreateDirectory($tempCommonDir) | Out-Null
+        Copy-Item -Path $script:compatibilityHelperPath -Destination (Join-Path -Path $tempCommonDir -ChildPath 'CompatibilityHelpers.ps1') -Force
+    }
+
     # Helper: remove temp directories reliably on Windows where file handles may linger.
     $script:RemoveTempRoot = {
         param([string]$Path)
@@ -219,7 +234,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             $validationFailure = $null
@@ -315,7 +330,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             $generatedIndex = ([System.IO.File]::ReadAllText((Join-Path -Path $tempRoot -ChildPath '.llm/skills-index.md'), [System.Text.Encoding]::UTF8)) -replace "`r", ''
@@ -371,7 +386,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             $validationFailure = $null
@@ -431,7 +446,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             { & $script:validatorPath -RootPath $tempRoot } | Should -Not -Throw
@@ -482,7 +497,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             { & $script:validatorPath -RootPath $tempRoot } | Should -Not -Throw
@@ -533,7 +548,7 @@ Describe "LLM harness automation" {
             )
 
             $tempUpdaterPath = Join-Path -Path $tempRoot -ChildPath 'Scripts/Utils/Quality/Update-LlmSkillsIndex.ps1'
-            Copy-Item -Path $script:indexUpdaterPath -Destination $tempUpdaterPath -Force
+            & $script:CopyUpdaterToTemp $tempUpdaterPath
             & $tempUpdaterPath -RootPath $tempRoot
 
             $validationFailure = $null

--- a/Tests/Utils/Remove-BOM.Tests.ps1
+++ b/Tests/Utils/Remove-BOM.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
     $script:removeBomScriptPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Remove-BOM.ps1"
     $script:gitCommand = Get-Command -Name "git" -ErrorAction SilentlyContinue
 
+    . (Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1")
     . $script:removeBomScriptPath
 
     function Resolve-CanonicalTempRoot {
@@ -23,7 +24,7 @@ BeforeAll {
 
         $canonicalBasePath = Resolve-CanonicalFileSystemPath -path $BasePath
         $canonicalTargetPath = Resolve-CanonicalFileSystemPath -path $TargetPath
-        return ([System.IO.Path]::GetRelativePath($canonicalBasePath, $canonicalTargetPath) -replace '\\', '/')
+        return ((Get-RelativePathCompat -BasePath $canonicalBasePath -TargetPath $canonicalTargetPath) -replace '\\', '/')
     }
 
     function Initialize-TestGitRepository {
@@ -68,14 +69,14 @@ Describe "Remove-BOM file discovery" {
             [bool]$UseResolveLinkTarget
         )
 
-        $resolvedPath = if ($IsWindows) {
+        $resolvedPath = if (Test-IsWindowsPlatform) {
             "C:\\runner\\_work\\_temp\\canonical-test-root"
         }
         else {
             "/private/var/folders/canonical-test-root"
         }
 
-        $missingIntermediate = if ($IsWindows) {
+        $missingIntermediate = if (Test-IsWindowsPlatform) {
             "C:\\runner"
         }
         else {
@@ -83,7 +84,7 @@ Describe "Remove-BOM file discovery" {
         }
 
         $resolvedItemPath = if ($UseResolveLinkTarget) {
-            if ($IsWindows) {
+            if (Test-IsWindowsPlatform) {
                 "C:\\runner\\alias\\canonical-test-root"
             }
             else {
@@ -94,7 +95,7 @@ Describe "Remove-BOM file discovery" {
             $resolvedPath
         }
 
-        $linkTargetPath = if ($IsWindows) {
+        $linkTargetPath = if (Test-IsWindowsPlatform) {
             "C:\\runner\\target\\canonical-test-root"
         }
         else {
@@ -139,7 +140,7 @@ Describe "Remove-BOM file discovery" {
         $actualCanonicalPath = Resolve-CanonicalFileSystemPath -path "ignored-by-mocks"
 
         $actualCanonicalPath | Should -Be $expectedCanonicalPath -Because "Scenario '$Scenario' should canonicalize without traversing intermediate path segments."
-        $expectedResolvedPathCalls = if ($IsWindows) { 1 } else { 2 }
+        $expectedResolvedPathCalls = if (Test-IsWindowsPlatform) { 1 } else { 2 }
         Assert-MockCalled -CommandName Get-Item -ParameterFilter { $LiteralPath -eq $resolvedPath } -Times $expectedResolvedPathCalls -Exactly
         Assert-MockCalled -CommandName Get-Item -ParameterFilter { $LiteralPath -eq $missingIntermediate } -Times 0 -Exactly
     }
@@ -199,7 +200,7 @@ Describe "Remove-BOM file discovery" {
             [string]$ResolvePathAliasPath
         )
 
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             Set-ItResult -Skipped -Because "Unix-style root alias canonicalization does not apply on Windows"
             return
         }
@@ -261,7 +262,7 @@ Describe "Remove-BOM file discovery" {
     }
 
     It "falls back to readlink when .NET providers fail to resolve top-level alias" {
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             Set-ItResult -Skipped -Because "Unix-style root alias canonicalization does not apply on Windows"
             return
         }
@@ -335,7 +336,7 @@ Describe "Remove-BOM file discovery" {
             [string]$LinkTargetPropertyValue
         )
 
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             Set-ItResult -Skipped -Because "Unix-style root alias canonicalization does not apply on Windows"
             return
         }

--- a/Tests/Utils/Run-PreCommitValidation.ArrayShape.Tests.ps1
+++ b/Tests/Utils/Run-PreCommitValidation.ArrayShape.Tests.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    . (Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1")
     $script:preCommitPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Run-PreCommitValidation.ps1"
     $script:preCommitContent = (Get-Content -Path $script:preCommitPath -Raw) -replace "`r", ""
 
@@ -124,7 +125,7 @@ Describe "Run-PreCommitValidation call-site and helper ownership contracts" {
             foreach ($line in @(Get-Content -Path $scriptFile.FullName)) {
                 $lineNumber++
                 if ($line -match '^\s*function\s+Convert-CapturedTextToLines\b') {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $portableRelativePath = $relativePath -replace '\\', '/'
                     $definitions.Add("${portableRelativePath}:$lineNumber") | Out-Null
                 }
@@ -195,7 +196,7 @@ Describe "Run-PreCommitValidation call-site and helper ownership contracts" {
                     continue
                 }
 
-                $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                 $portableRelativePath = $relativePath -replace '\\', '/'
                 $violations.Add("${portableRelativePath}:$($commandNode.Extent.StartLineNumber) command '$commandName'") | Out-Null
             }

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -750,7 +750,11 @@ Describe "Cross-language quality platform conventions" {
         $sharedHelper | Should -Match 'Invoke-WebRequest'
         $sharedHelper | Should -Match 'Get-FileHash'
         $sharedHelper | Should -Match 'System\.Diagnostics\.ProcessStartInfo'
-        $sharedHelper | Should -Match 'ArgumentList\.Add'
+        # Argument passing must go through the portable shim (native ArgumentList on 7+,
+        # escaped .Arguments string on Windows PowerShell 5.1) rather than touching the
+        # .NET Core-only ArgumentList collection directly, which throws on 5.1.
+        $sharedHelper | Should -Match 'Set-PortableProcessArguments'
+        $sharedHelper | Should -Not -Match '\$\w+\.ArgumentList\.Add'
         $sharedHelper | Should -Match 'W_\$\(\$Context\.DiagnosticPrefix\)_PLATFORM_FALLBACK'
         $sharedHelper | Should -Match 'E_\$\(\$Context\.DiagnosticPrefix\)_HASH_MISMATCH'
         $sharedHelper | Should -Match 'E_\$\(\$Context\.DiagnosticPrefix\)_PLATFORM_UNSUPPORTED'
@@ -804,7 +808,11 @@ Describe "Cross-language quality platform conventions" {
         $sharedHelper | Should -Match 'Invoke-WebRequest'
         $sharedHelper | Should -Match 'Get-FileHash'
         $sharedHelper | Should -Match 'System\.Diagnostics\.ProcessStartInfo'
-        $sharedHelper | Should -Match 'ArgumentList\.Add'
+        # Argument passing must go through the portable shim (native ArgumentList on 7+,
+        # escaped .Arguments string on Windows PowerShell 5.1) rather than touching the
+        # .NET Core-only ArgumentList collection directly, which throws on 5.1.
+        $sharedHelper | Should -Match 'Set-PortableProcessArguments'
+        $sharedHelper | Should -Not -Match '\$\w+\.ArgumentList\.Add'
         $sharedHelper | Should -Match 'W_\$\(\$Context\.DiagnosticPrefix\)_PLATFORM_FALLBACK'
         $sharedHelper | Should -Match 'E_\$\(\$Context\.DiagnosticPrefix\)_HASH_MISMATCH'
         $sharedHelper | Should -Match 'E_\$\(\$Context\.DiagnosticPrefix\)_PLATFORM_UNSUPPORTED'
@@ -1009,12 +1017,15 @@ Describe "Cross-language quality platform conventions" {
         $windowsChecksTests | Should -Match 'Arguments\s*='
     }
 
-    It "uses System.Diagnostics.Process with ArgumentList in Invoke-AutoHotkeyCommand and avoids LASTEXITCODE dependency" {
+    It "uses System.Diagnostics.Process with portable argument passing in Invoke-AutoHotkeyCommand and avoids LASTEXITCODE dependency" {
         $windowsChecksPath = Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Utils/Quality/Invoke-WindowsLanguageChecks.ps1'
         $windowsChecks = Get-Content -Path $windowsChecksPath -Raw
 
         $windowsChecks | Should -Match 'System\.Diagnostics\.ProcessStartInfo'
-        $windowsChecks | Should -Match 'ArgumentList\.Add'
+        # Portable argument passing (native ArgumentList on 7+, escaped .Arguments string on
+        # Windows PowerShell 5.1) instead of the .NET Core-only ArgumentList collection.
+        $windowsChecks | Should -Match 'Set-PortableProcessArguments'
+        $windowsChecks | Should -Not -Match '\$\w+\.ArgumentList\.Add'
         $windowsChecks | Should -Match 'RedirectStandardOutput'
         $windowsChecks | Should -Match 'RedirectStandardError'
         $windowsChecks | Should -Match 'E_AHK_PROCESS_EXECUTION_FAILED'
@@ -2957,7 +2968,11 @@ Describe "Utility configuration safety conventions" {
         $content | Should -Match 'Test-IsLinkOrReparsePoint\s+-Item\s+\$resolvedArtifactDirectoryItem'
         $content | Should -Match '\[System\.IO\.FileAttributes\]::ReparsePoint'
         $content | Should -Match 'LinkType'
-        $content | Should -Match 'ResolveLinkTarget\(\$true\)'
+        # The canonical-path guard resolves symbolic links to their FINAL target through the
+        # portable Get-PortableLinkTarget shim (native ResolveLinkTarget($true) on 7+, the
+        # LinkTarget/Target ETS members on Windows PowerShell 5.1) rather than calling the
+        # .NET 6-only ResolveLinkTarget method directly, which throws on 5.1.
+        $content | Should -Match 'Get-PortableLinkTarget'
         $content | Should -Match 'isolated Pester failure artifact directory must not be a symbolic link or reparse point'
         $content | Should -Match 'Resolve-CanonicalPath\s+-Path\s+\$artifactDirectory'
         $content | Should -Match 'E_CONFIG_ERROR: isolated Pester failure artifact path must be outside repository root'

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
     }
 
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    . (Join-Path -Path $PSScriptRoot -ChildPath "../../Scripts/Utils/Common/CompatibilityHelpers.ps1")
     $script:migratedScripts = @(
         "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1",
         "Scripts/Utils/BackupDxMessaging.ps1",
@@ -202,7 +203,7 @@ Describe "Scope safety conventions" {
                 foreach ($scriptVariable in $scriptScopeVariables) {
                     $variableName = $scriptVariable.VariablePath.UserPath
                     if ($paramNames -contains $variableName) {
-                        $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                        $relative = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                         $violations.Add("${relative}:$($scriptVariable.Extent.StartLineNumber) variable '$variableName' from function '$($function.Name)' referenced at script scope") | Out-Null
                     }
                 }
@@ -327,7 +328,10 @@ Describe "Scope safety conventions" {
         $upperOwnerMatches.Count | Should -Be 0
         $upperRepoMatches.Count | Should -Be 0
 
-        $scriptContent | Should -Match 'function\s+Format-UnresolvedThreadsAsJson[\s\S]*ConvertTo-Json\s+-Depth\s+8\s+-AsArray'
+        # Array-stable singleton output is preserved via ConvertTo-JsonArrayCompat, the
+        # cross-version replacement for `ConvertTo-Json -AsArray` (absent on Windows
+        # PowerShell 5.1).
+        $scriptContent | Should -Match 'function\s+Format-UnresolvedThreadsAsJson[\s\S]*ConvertTo-JsonArrayCompat\s+-InputObject\s+\$Records\s+-Depth\s+8'
 
         $testsContent | Should -Match 'Format-UnresolvedThreadsAsJson'
         $testsContent | Should -Match '\(\$propertyNames\s+-ccontains\s+"path"\)\s+\|\s+Should\s+-BeTrue'
@@ -394,12 +398,17 @@ Describe "Scope safety conventions" {
         $content | Should -Not -Match 'function\s+Invoke-Main[\s\S]*IsNullOrWhiteSpace\(\$OutputPath\)[\s\S]*Write-RenderedOutputToFile'
     }
 
-    It "keeps PowerShell argument-completion metadata for unresolved PR comments" {
+    It "keeps PowerShell argument metadata cross-version safe for unresolved PR comments" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
         $content = Get-Content -Path $fullPath -Raw
 
-        $content | Should -Match '\[ArgumentCompletions\("github\.com"\)\]'
-        $content | Should -Match '\[ArgumentCompletions\("text",\s*"json"\)\]'
+        # OutputFormat must use [ValidateSet] (validation + completion, works on both
+        # Windows PowerShell 5.1 and PowerShell 7+) rather than the 7+-only
+        # [ArgumentCompletions] attribute.
+        $content | Should -Match '\[ValidateSet\("text",\s*"json"\)\]'
+        # [ArgumentCompletions] is a PowerShell 7+ attribute that fails to parse on
+        # Windows PowerShell 5.1 and must not be reintroduced.
+        $content | Should -Not -Match '\[ArgumentCompletions\('
     }
 
     It "keeps Increment-Version direct-run invocation guard" {
@@ -1030,7 +1039,7 @@ Describe "Cross-language quality platform conventions" {
 
         foreach ($file in $ahkFiles) {
             $content = Get-Content -Path $file.FullName -Raw -ErrorAction Stop
-            $relativePath = ([System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)).Replace([System.IO.Path]::DirectorySeparatorChar, '/').Replace([System.IO.Path]::AltDirectorySeparatorChar, '/')
+            $relativePath = (Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName).Replace([System.IO.Path]::DirectorySeparatorChar, '/').Replace([System.IO.Path]::AltDirectorySeparatorChar, '/')
             $content | Should -Match '(?ms)\A(?:\xEF\xBB\xBF)?(?:[ \t]*;[^\r\n]*\r?\n|[ \t]*\r?\n)*[ \t]*#Requires\s+AutoHotkey\s+v2(?:\.\d+)?\b' -Because "$relativePath must declare #Requires AutoHotkey v2 (or v2.x) at the top with only optional leading blank/comment lines"
         }
     }
@@ -1110,7 +1119,7 @@ Describe "Quality script executable guardrails" {
 
         $macChecksPath = Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Utils/Quality/Invoke-MacOSLanguageChecks.sh'
         $bashPathArgument = $macChecksPath
-        if ($IsWindows) {
+        if (Test-IsWindowsPlatform) {
             $cygpath = Get-Command -Name cygpath -ErrorAction SilentlyContinue
             if ($null -ne $cygpath) {
                 $convertedPath = @(& $cygpath.Source -u $macChecksPath 2>$null | Select-Object -First 1)
@@ -1180,7 +1189,7 @@ Describe "Quality config file conventions" {
         $hookPaths = @($script:preCommitHookPath, $script:prePushHookPath)
 
         foreach ($hookPath in $hookPaths) {
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $hookPath)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $hookPath
             $bytes = [System.IO.File]::ReadAllBytes($hookPath)
 
             $bytes.Length | Should -BeGreaterThan 0 -Because ("{0} should not be empty" -f $relativePath)
@@ -1213,7 +1222,7 @@ Describe "Shell quality conventions" {
         $negatedExitPropagationPattern = '(?m)^\s*if\s+!\s+[^\n;]+;\s+then\s*$\n^\s*(?:return|exit)\s+\$\?\s*$'
 
         foreach ($shellFile in $shellFiles) {
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $shellFile.FullName)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $shellFile.FullName
             $content = (Get-Content -Path $shellFile.FullName -Raw) -replace "`r", ''
             if ($content -match $negatedCommandSubstitutionCapturePattern -or $content -match $negatedExitPropagationPattern) {
                 $violations.Add($relativePath) | Out-Null
@@ -1484,7 +1493,7 @@ Describe "Shell quality conventions" {
                 }
 
                 if (-not $hasInlineReason -and -not $hasNeighborReason) {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $violations.Add("${relativePath}:$($index + 1)") | Out-Null
                 }
             }
@@ -1508,7 +1517,7 @@ Describe "Directory restoration safety conventions" {
                 continue
             }
 
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
 
             # Per-occurrence check: split content on each Push-Location invocation.
             # Each part after index 0 is the content that follows one Push-Location call.
@@ -1590,7 +1599,7 @@ Describe "File stream safety conventions" {
         $powerShellScripts = @(Get-ChildItem -LiteralPath $scriptsRoot -Filter '*.ps1' -File -Recurse -ErrorAction Stop)
 
         foreach ($scriptFile in $powerShellScripts) {
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
             $content = (Get-Content -LiteralPath $scriptFile.FullName -Raw) -replace "`r", ''
             $openReadMatches = [regex]::Matches($content, '\[System\.IO\.File\]::OpenRead\s*\(')
 
@@ -1814,7 +1823,7 @@ Describe "Restore script safety conventions" {
         $powershellRestore | Should -Not -Match '(?-i)Microsoft\.Powershell_profile\.ps1'
         $powershellRestore | Should -Match '\$PROFILE\.CurrentUserCurrentHost'
         $powershellRestore | Should -Match '\$PROFILE\.CurrentUserAllHosts'
-        $powershellRestore | Should -Match 'if\s*\(\$IsWindows\)\s*\{[\s\S]*Join-Path\s+-Path\s+\$HOME\s+-ChildPath\s+''Documents''[\s\S]*Join-Path\s+-Path\s+\$documentsPath\s+-ChildPath\s+''WindowsPowerShell''' -Because 'Legacy Windows PowerShell paths should only be restored on Windows.'
+        $powershellRestore | Should -Match 'if\s*\(Test-IsWindowsPlatform\)\s*\{[\s\S]*Join-Path\s+-Path\s+\$HOME\s+-ChildPath\s+''Documents''[\s\S]*Join-Path\s+-Path\s+\$documentsPath\s+-ChildPath\s+''WindowsPowerShell''' -Because 'Legacy Windows PowerShell paths should only be restored on Windows (via the cross-version Test-IsWindowsPlatform helper).'
         $powershellRestore | Should -Not -Match '\$HOME\\Documents\\PowerShell'
         $powershellRestore | Should -Not -Match '\$HOME\\Documents\\Powershell'
         $powershellRestore | Should -Match 'Test-Path\s+-LiteralPath\s+\$sourcePath\s+-PathType\s+Leaf'
@@ -1967,7 +1976,7 @@ Describe "Backup script safety conventions" {
 
             foreach ($scriptFile in $backupRestoreScripts) {
                 $content = (Get-Content -Path $scriptFile.FullName -Raw) -replace "`r", ''
-                $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                 $content | Should -Match 'Set-StrictMode\s+-Version\s+Latest' -Because (
                     '{0} is part of backup/restore flow and must declare strict mode.' -f $relativePath
                 )
@@ -2029,7 +2038,7 @@ Describe "Backup script safety conventions" {
         $powershellBackup | Should -Match 'Join-Path\s+-Path\s+\(Join-Path\s+-Path\s+\$baseDirectory\s+-ChildPath\s+"Config"\)\s+-ChildPath\s+"Powershell"'
         $powershellBackup | Should -Match '\$PROFILE\.CurrentUserCurrentHost'
         $powershellBackup | Should -Match '\$PROFILE\.CurrentUserAllHosts'
-        $powershellBackup | Should -Match '\$pathComparer\s*=\s*if\s*\(\$IsWindows\)'
+        $powershellBackup | Should -Match '\$pathComparer\s*=\s*if\s*\(Test-IsWindowsPlatform\)'
         $powershellBackup | Should -Match 'HashSet\[string\]\(\$pathComparer\)'
         $powershellBackup | Should -Match 'W_POWERSHELL_BACKUP_PROFILE_MISSING\('
         $powershellBackup | Should -Match 'PowerShell backup profile discovery diagnostics:'
@@ -2065,7 +2074,7 @@ Describe "Backup script safety conventions" {
         $powerToysBackup | Should -Match 'E_POWERTOYS_BACKUP_ROBOCOPY_FAILED'
         $powerToysBackup | Should -Match 'E_POWERTOYS_BACKUP_SOURCE_MISSING'
         $powerToysBackup | Should -Match 'Test-Path\s+-LiteralPath\s+\$backupFolder\s+-PathType\s+Container'
-        $powerToysBackup | Should -Match 'New-Item\s+-LiteralPath\s+\$backupFolder\s+-ItemType\s+Directory'
+        $powerToysBackup | Should -Match '\[System\.IO\.Directory\]::CreateDirectory\(\$backupFolder\)'
         $powerToysBackup | Should -Match 'Get-ChildItem\s+-LiteralPath\s+\$backupFolder\s+-Force\s+-ErrorAction\s+Stop'
         $powerToysBackup | Should -Match 'Remove-Item\s+-LiteralPath\s+\$backupEntry\.FullName'
         $powerToysBackup | Should -Not -Match 'Remove-Item[^\r\n]*-ErrorAction\s+SilentlyContinue'
@@ -2141,7 +2150,7 @@ Describe "Backup script safety conventions" {
 
         $violations = New-Object System.Collections.Generic.List[string]
         foreach ($scriptFile in $scriptFiles) {
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
             $content = (Get-Content -Path $scriptFile.FullName -Raw) -replace "`r", ''
 
             if ($content -match $ForbiddenPattern) {
@@ -2190,7 +2199,7 @@ Describe "Path derivation safety conventions" {
             $lines = @(Get-Content -Path $scriptFile.FullName)
             for ($index = 0; $index -lt $lines.Count; $index++) {
                 if ($lines[$index] -match '\$[A-Za-z0-9_]+\s*=\s*"\$[A-Za-z0-9_]+[\\/]\.\.') {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $violations.Add("${relativePath}:$($index + 1)") | Out-Null
                 }
             }
@@ -2237,12 +2246,14 @@ Describe "Path derivation safety conventions" {
         foreach ($testFile in $testFiles) {
             $content = (Get-Content -LiteralPath $testFile.FullName -Raw) -replace "`r", ''
             $usesGetTempPath = $content -match '\[System\.IO\.Path\]::GetTempPath\(\)'
-            $usesGetRelativePath = $content -match '\[System\.IO\.Path\]::GetRelativePath\('
+            # Cover both the native method and the cross-version Get-RelativePathCompat shim
+            # so files that migrated to the portable helper still fall under this policy.
+            $usesGetRelativePath = ($content -match '\[System\.IO\.Path\]::GetRelativePath\(') -or ($content -match '\bGet-RelativePathCompat\b')
             if ($usesGetTempPath -and $usesGetRelativePath) {
                 $definesHelper = $content -match 'function\s+Resolve-CanonicalTempRoot\s*\{'
                 $usesHelper = $content -match 'Resolve-CanonicalTempRoot\s+-Path\b'
                 if (-not ($definesHelper -and $usesHelper)) {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $testFile.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $testFile.FullName
                     $violations.Add($relativePath) | Out-Null
                 }
             }
@@ -2664,7 +2675,7 @@ Describe "Dependabot manifest coverage drift conventions" {
             $sampleFiles = @(
                 $foundFiles |
                     Select-Object -First 3 |
-                    ForEach-Object { [System.IO.Path]::GetRelativePath($script:repoRoot, $_.FullName) }
+                    ForEach-Object { Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $_.FullName }
             )
 
             $violations.Add(("{0} requires ecosystem '{1}' (matches={2}; example files: {3}; diagnostics: {4})" -f $mapping.Filter, $mapping.Ecosystem, $foundFiles.Count, ($sampleFiles -join '; '), $scanDiagnostics)) | Out-Null
@@ -2725,7 +2736,7 @@ Describe "JSON parsing conventions" {
             }
 
             if ($content -match '(?m)^[^#\r\n]*\bConvertFrom-Json\b(?!-)') {
-                $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                $relative = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                 $violations.Add($relative) | Out-Null
             }
         }
@@ -2916,7 +2927,7 @@ Describe "Utility configuration safety conventions" {
             foreach ($line in @(Get-Content -Path $scriptFile.FullName)) {
                 $lineNumber++
                 if ($line -match '^\s*function\s+Convert-CapturedTextToLines\b') {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $portableRelativePath = $relativePath -replace '\\', '/'
                     $definitions.Add("${portableRelativePath}:$lineNumber") | Out-Null
                 }
@@ -3288,8 +3299,8 @@ $result = "value {0} {1}" -f
 
         $content | Should -Match 'function\s+ConvertTo-PortableFormatOperatorPath\b'
         $content | Should -Match "function\s+ConvertTo-PortableFormatOperatorPath[\s\S]*?-replace\s+'\[\\\\/\]\+'\s*,\s*'/'"
-        $content | Should -Match 'relativeParsePath\s*=\s*ConvertTo-PortableFormatOperatorPath\s+-PathValue\s+\(\[System\.IO\.Path\]::GetRelativePath'
-        $content | Should -Match 'relativePath\s*=\s*ConvertTo-PortableFormatOperatorPath\s+-PathValue\s+\(\[System\.IO\.Path\]::GetRelativePath'
+        $content | Should -Match 'relativeParsePath\s*=\s*ConvertTo-PortableFormatOperatorPath\s+-PathValue\s+\(Get-RelativePathCompat\b'
+        $content | Should -Match 'relativePath\s*=\s*ConvertTo-PortableFormatOperatorPath\s+-PathValue\s+\(Get-RelativePathCompat\b'
     }
 
     It "emits verbose diagnostics for module path candidate handling in ModuleHelpers" {
@@ -3630,7 +3641,7 @@ $result = "value {0} {1}" -f
         foreach ($scriptFile in $utilsScripts) {
             $content = Get-Content -Path $scriptFile.FullName -Raw
             if ($content -match '(?im)^\s*Import-Module\s+~[/\\]' -or $content -match '(?im)^\s*Import-Module\s+\$env:USERPROFILE[/\\]') {
-                $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                $relative = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                 $violations.Add($relative) | Out-Null
             }
         }
@@ -3782,7 +3793,7 @@ Describe "PowerShell formatting conventions" {
                     }
 
                     if ($isInsideParamBlock) {
-                        $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+                        $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
                         $violations.Add("${relativePath}:$lineNumber") | Out-Null
                     }
                 }
@@ -3817,7 +3828,7 @@ Describe "PowerShell formatting conventions" {
                 $lines = @(Get-Content -Path $file.FullName)
                 for ($index = 0; $index -lt $lines.Count; $index++) {
                     if ($lines[$index] -match '^(?: )*\t+') {
-                        $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+                        $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
                         $violations.Add("${relativePath}:$($index + 1)") | Out-Null
                     }
                 }
@@ -3846,7 +3857,7 @@ Describe "Retry test determinism conventions" {
                 continue
             }
 
-            $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+            $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
             $errorSummary = ($fileParseErrors | ForEach-Object { $_.Message }) -join '; '
             $violations.Add(("{0}: {1}" -f $relativePath, $errorSummary)) | Out-Null
         }
@@ -3865,7 +3876,7 @@ Describe "Retry test determinism conventions" {
             $lines = @(Get-Content -Path $file.FullName)
             for ($index = 0; $index -lt $lines.Count; $index++) {
                 if ($lines[$index] -match '^\s+''@$' -or $lines[$index] -match '^\s+"@$') {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
                     $violations.Add("${relativePath}:$($index + 1)") | Out-Null
                 }
             }
@@ -3918,7 +3929,7 @@ Describe "Retry test determinism conventions" {
                 } | Select-Object -First 1
 
                 if ($null -eq $describeScriptBlockExpression) {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
                     $violations.Add("${relativePath}:$($describe.Extent.StartLineNumber):missing describe script block") | Out-Null
                     continue
                 }
@@ -3976,7 +3987,7 @@ Describe "Retry test determinism conventions" {
                         }, $true)).Count -gt 0
 
                 if (-not $hasDefaultSleepMock) {
-                    $relativePath = [System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)
+                    $relativePath = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $file.FullName
                     $violations.Add("${relativePath}:$($describe.Extent.StartLineNumber)") | Out-Null
                 }
             }
@@ -4109,7 +4120,7 @@ Describe "UTF-8 encoding conventions" {
             $lines = @(Get-Content -Path $scriptFile.FullName)
             for ($i = 0; $i -lt $lines.Count; $i++) {
                 if ($lines[$i] -match 'WriteAllText\(' -and $lines[$i] -match '\[System\.Text\.Encoding\]::UTF8') {
-                    $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relative = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $violations.Add("${relative}:$($i + 1)") | Out-Null
                 }
             }
@@ -4144,7 +4155,7 @@ Describe "PowerShell return safety conventions" {
             $lines = @(Get-Content -Path $scriptFile.FullName)
             for ($i = 0; $i -lt $lines.Count; $i++) {
                 if ($lines[$i] -match '\breturn\s+@\(\)' -and $lines[$i] -notmatch '#\s*array-unwrap-safe') {
-                    $relative = [System.IO.Path]::GetRelativePath($script:repoRoot, $scriptFile.FullName)
+                    $relative = Get-RelativePathCompat -BasePath $script:repoRoot -TargetPath $scriptFile.FullName
                     $violations.Add("${relative}:$($i + 1)") | Out-Null
                 }
             }
@@ -4224,8 +4235,8 @@ Describe "Quality tooling shared-helper conventions" {
         $content | Should -Match 'Start-Sleep\s+-Seconds\s+\$backoffSeconds' -Because (
             "shared helper download retry must apply backoff between attempts."
         )
-        $content | Should -Match '\$IsWindows\s*\)\s*\{\s*\[System\.StringComparison\]::OrdinalIgnoreCase\s*\}' -Because (
-            "shared helper repository-boundary check must use OrdinalIgnoreCase only on Windows."
+        $content | Should -Match 'Test-IsWindowsPlatform\s*\)\s*\{\s*\[System\.StringComparison\]::OrdinalIgnoreCase\s*\}' -Because (
+            "shared helper repository-boundary check must use OrdinalIgnoreCase only on Windows (via the cross-version Test-IsWindowsPlatform helper)."
         )
         $content | Should -Match 'else\s*\{\s*\[System\.StringComparison\]::Ordinal\s*\}' -Because (
             "shared helper repository-boundary check must use Ordinal comparison on Linux/macOS."


### PR DESCRIPTION
## Summary

This PR makes the PowerShell tooling portable across Windows PowerShell 5.1 and PowerShell 7+, and adds compatibility checks so regressions are caught early in local validation and CI.

## What Changed

- Added a shared compatibility helper layer used by scripts and profiles:
  - New compatibility functions for OS detection, relative paths, and JSON behavior across 5.1 and 7+.
- Added a dedicated compatibility quality gate:
  - New `Invoke-CompatibilityChecks.ps1` script.
  - New compatibility allowlist for approved exceptions.
- Updated key scripts and profile files to use compatibility-safe patterns.
- Expanded CI and validation wiring to run compatibility checks consistently.
- Added and updated tests to enforce compatibility conventions and helper behavior.

## User Impact

- Scripts are more reliable across Windows, macOS, and Linux.
- Users running Windows PowerShell 5.1 get safer behavior under strict mode.
- CI failures should be clearer and caught earlier for cross-version issues.

## Scope

- 43 files changed
- 1,643 insertions, 143 deletions
- New files include:
  - `Scripts/Utils/Common/CompatibilityHelpers.ps1`
  - `Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1`
  - `Scripts/Utils/Quality/compatibility-allowlist.psd1`
  - `Tests/Utils/CompatibilityConventions.Tests.ps1`
  - `Tests/Utils/CompatibilityHelpers.Tests.ps1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad touch of backup/restore, quality runners, and process/HTTP paths; mitigated by new gates and dual-edition CI, but regressions could still affect local/CI script execution.
> 
> **Overview**
> This PR establishes a **Windows PowerShell 5.1 + PowerShell 7+** contract for repo PowerShell and wires enforcement into CI.
> 
> **Shared shims:** New `CompatibilityHelpers.ps1` centralizes portable OS checks (`Test-Is*Platform`), relative paths (`Get-RelativePathCompat`), JSON (`ConvertTo-JsonArrayCompat` / `ConvertFrom-JsonCompat`), process args/kill (`Set-PortableProcessArguments`, `Stop-ProcessTreePortably`), and link resolution (`Get-PortableLinkTarget`). Call sites across backup/restore/update, quality tooling, GitHub utilities, and profiles dot-source it and replace `$IsWindows`/`$IsMacOS`/`$IsLinux`, `New-Item -LiteralPath` for dirs, `[Path]::GetRelativePath`, `ArgumentList`/`Kill($true)`, bare `ConvertFrom-Json -Depth/-NoEnumerate`, and unguarded PSReadLine prediction options.
> 
> **Static gate:** `Invoke-CompatibilityChecks.ps1` runs PSScriptAnalyzer `PSUseCompatible*` rules plus AST checks (forbidden automatic variables, `Invoke-WebRequest` without `-UseBasicParsing`, Core-only .NET members) with `compatibility-allowlist.psd1` for external tools/Pester DSL.
> 
> **CI:** `script-quality.yml` adds `powershell-compat-analyzer`, Pester lanes on WinPS 5.1 and pwsh 7, and folds them into the validation summary.
> 
> **Tests/docs:** `CompatibilityConventions.Tests.ps1` (and related test updates) lock the contract; `.llm/context.md` documents required idioms; clipboard/header tests adapt for 5.1 (e.g. `Set-ClipboardValue` seam, `System.Net.Http` load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fdf506095234cfa373731e45b4e52068ba134d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->