### PR TITLE
bugfix: Script Quality Fixes

### DIFF
--- a/.github/workflows/script-quality.yml
+++ b/.github/workflows/script-quality.yml
@@ -789,9 +789,9 @@ jobs:
           restore-keys: |
             psmodules-${{ runner.os }}-winps51-
 
-      - name: Install Pester 5 and PSScriptAnalyzer (Windows PowerShell 5.1)
+      - name: Install Pester 5 (Windows PowerShell 5.1)
         shell: powershell
-        run: ./Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules Pester,PSScriptAnalyzer
+        run: ./Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules Pester
 
       - name: Run Pester suite under Windows PowerShell 5.1
         shell: powershell
@@ -848,9 +848,9 @@ jobs:
           restore-keys: |
             psmodules-${{ runner.os }}-pwsh7-
 
-      - name: Install Pester 5 and PSScriptAnalyzer (PowerShell 7+)
+      - name: Install Pester 5 (PowerShell 7+)
         shell: pwsh
-        run: ./Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules Pester,PSScriptAnalyzer
+        run: ./Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules Pester
 
       - name: Run Pester suite under PowerShell 7+
         shell: pwsh

--- a/.llm/skill-details/cross-platform-powershell.md
+++ b/.llm/skill-details/cross-platform-powershell.md
@@ -2,6 +2,7 @@
 
 This expanded guide supports the lightweight skill stub in `.llm/skills/cross-platform-powershell.md`.
 Applies to shared scripts (e.g., `Scripts/Utils/`); platform-specific directories like `Scripts/Komorebi/` are exempt.
+Shared repository PowerShell must run on both Windows PowerShell 5.1 and PowerShell 7+.
 
 ## Path Handling And Separator Safety
 
@@ -72,24 +73,29 @@ Use `-FollowSymlink` only when that behavior is explicitly intended.
 
 ## OS Detection And Conditional Logic
 
-Use PowerShell 7+ automatic variables for OS detection:
+Use the repository compatibility helpers for OS detection. `$IsWindows`, `$IsMacOS`,
+and `$IsLinux` do not exist on Windows PowerShell 5.1 and throw under strict mode.
 
 ```powershell
-if ($IsWindows) {
+if (Test-IsWindowsPlatform) {
     # Windows-specific logic
-} elseif ($IsMacOS) {
+} elseif (Test-IsMacOSPlatform) {
     # macOS-specific logic
-} elseif ($IsLinux) {
+} elseif (Test-IsLinuxPlatform) {
     # Linux-specific logic
 }
 ```
 
-Do not use `[System.Runtime.InteropServices.RuntimeInformation]` or `$env:OS` checks when the automatic variables are available. They are cleaner and more reliable in PowerShell 7+.
+Dot-source `Scripts/Utils/Common/CompatibilityHelpers.ps1` before using these helpers.
+Do not use `[System.Runtime.InteropServices.RuntimeInformation]`, `$env:OS`, or bare
+PowerShell 7+ automatic variables for OS detection in shared scripts. For other runtime
+facts that require .NET APIs, follow the compatibility guard and justified
+`SuppressMessageAttribute` guidance in `.llm/context.md`.
 
 For commands that differ by platform, use a lookup pattern:
 
 ```powershell
-$openCmd = if ($IsWindows) { 'start' } elseif ($IsMacOS) { 'open' } else { 'xdg-open' }
+$openCmd = if (Test-IsWindowsPlatform) { 'start' } elseif (Test-IsMacOSPlatform) { 'open' } else { 'xdg-open' }
 ```
 
 ## Line Ending And Encoding Safety
@@ -131,6 +137,12 @@ When comparing file names or paths, use `[System.StringComparison]::OrdinalIgnor
 if ($fileName.Equals('README.md', [System.StringComparison]::OrdinalIgnoreCase)) { ... }
 ```
 
+PowerShell command names, parameter names, variable names, type/member names, and member
+invocation are generally case-insensitive. AST-backed policy checks that model PowerShell
+language behavior should use case-insensitive comparisons (`-ieq`/`-ine`, helper functions,
+or case-insensitive collections) for those identifiers, while keeping file/path comparisons
+platform-appropriate.
+
 When creating files programmatically, use consistent lowercase or match existing conventions exactly.
 File permission differences: Unix requires `chmod +x` for executable scripts; use platform checks before setting permissions.
 When resolving POSIX/native tools from PowerShell (`chmod`, `readlink`, `test`), use
@@ -140,7 +152,7 @@ allow functions, aliases, or Pester helpers to shadow the external executable.
 Environment variable `$env:PATH` uses `;` as separator on Windows and `:` on Unix:
 
 ```powershell
-$pathSep = if ($IsWindows) { ';' } else { ':' }
+$pathSep = if (Test-IsWindowsPlatform) { ';' } else { ':' }
 $entries = $env:PATH -split [regex]::Escape($pathSep)
 ```
 
@@ -178,7 +190,7 @@ Avoid `Where-Object` and `ForEach-Object` in tight loops. Use `foreach` statemen
 # Fast: foreach statement
 foreach ($item in $collection) { ... }
 
-# Fast: method syntax (PS 7+)
+# Fast: PowerShell collection method syntax
 $filtered = $collection.Where({ $_.Status -eq 'Active' })
 
 # Slower: pipeline cmdlets in tight loops
@@ -255,7 +267,7 @@ Emit structured error codes (`E_PREFIX_DETAIL`) for actionable diagnostics.
 ## Workflow
 
 1. Use `Join-Path` and `[System.IO.Path]` for all path construction.
-2. Use `$IsWindows`, `$IsMacOS`, `$IsLinux` for platform branching.
+2. Use `Test-IsWindowsPlatform`, `Test-IsMacOSPlatform`, and `Test-IsLinuxPlatform` for platform branching.
 3. Normalize line endings before regex or string comparison.
 4. Use exact file name casing; test on case-sensitive file systems.
 5. Write files with explicit UTF-8 no-BOM encoding.

--- a/.llm/skills-index.md
+++ b/.llm/skills-index.md
@@ -28,7 +28,7 @@ This file is generated. Do not edit generated sections manually.
 
 | Skill Card | Expanded Guide | Trigger Keywords | Usage |
 | --- | --- | --- | --- |
-| [Cross Platform PowerShell](./skills/cross-platform-powershell.md) | [Expanded Guide](./skill-details/cross-platform-powershell.md) | cross-platform, powershell portability, path separator, os detection, line endings, platform compatibility, case sensitivity, git bash, bash_env, processstartinfo path, fake-command harness | Write portable PowerShell that runs on Windows, macOS, and Linux |
+| [Cross Platform PowerShell](./skills/cross-platform-powershell.md) | [Expanded Guide](./skill-details/cross-platform-powershell.md) | cross-platform, powershell portability, path separator, os detection, line endings, platform compatibility, case sensitivity, git bash, bash_env, processstartinfo path, fake-command harness | Write portable PowerShell that runs on Windows PowerShell 5.1 and PowerShell 7+ across Windows, macOS, and Linux |
 | [Devcontainer Bootstrap](./skills/devcontainer-bootstrap.md) | [Expanded Guide](./skill-details/devcontainer-bootstrap.md) | devcontainer, bootstrap, toolchain, setup parity | Use devcontainer bootstrap for consistent quality tooling |
 | [macOS AppleScript Validation](./skills/macos-applescript-validation.md) | [Expanded Guide](./skill-details/macos-applescript-validation.md) | macos, applescript, osacompile, migration fallback | Keep macOS AppleScript validation migration-safe |
 | [Windows Language Validation](./skills/windows-language-validation.md) | [Expanded Guide](./skill-details/windows-language-validation.md) | windows, autohotkey, batch, fast lane, runtime budget | Preserve Windows PR lane validation contracts |

--- a/.llm/skills/cross-platform-powershell.md
+++ b/.llm/skills/cross-platform-powershell.md
@@ -1,8 +1,8 @@
-<!-- trigger: cross-platform, powershell portability, path separator, os detection, line endings, platform compatibility, case sensitivity, git bash, bash_env, processstartinfo path, fake-command harness | Write portable PowerShell that runs on Windows, macOS, and Linux | Platform | skill-details/cross-platform-powershell.md -->
+<!-- trigger: cross-platform, powershell portability, path separator, os detection, line endings, platform compatibility, case sensitivity, git bash, bash_env, processstartinfo path, fake-command harness | Write portable PowerShell that runs on Windows PowerShell 5.1 and PowerShell 7+ across Windows, macOS, and Linux | Platform | skill-details/cross-platform-powershell.md -->
 
 # Cross-Platform PowerShell
 
-Lightweight skill card for writing portable PowerShell 7+ scripts across Windows, macOS, and Linux.
+Lightweight skill card for writing portable PowerShell that runs on Windows PowerShell 5.1 and PowerShell 7+ across Windows, macOS, and Linux.
 
 - Expanded guide: [Cross-Platform PowerShell (Expanded)](../skill-details/cross-platform-powershell.md)
 - Scope: applies to shared scripts (e.g., `Scripts/Utils/`); not for platform-specific directories like `Scripts/Komorebi/` or `Scripts/WinGet/`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         name: powershell-format
         entry: pwsh -NoLogo -NoProfile -File Scripts/Utils/Quality/Format-PowerShellFiles.ps1
         language: system
-        files: '^(Scripts|Tests)/.*\.ps1$'
+        files: '^(Scripts|Tests|Config/Powershell)/.*\.ps1$'
         pass_filenames: true
         require_serial: true
         stages: [pre-commit]
@@ -67,7 +67,7 @@ repos:
         name: powershell-precommit-validation
         entry: pwsh -NoLogo -NoProfile -File Scripts/Utils/Run-PreCommitValidation.ps1
         language: system
-        files: '^(Scripts/Utils/.*\.ps1|Tests/Utils/.*\.Tests\.ps1|Tests/GitHub/.*\.ps1|Scripts/AutoHotKey/.*\.ahk|Config/\.config/.*\.ahk|Scripts/.*\.bat|Scripts/.*\.sh|\.devcontainer/.*\.sh|\.githooks/(pre-commit|pre-push)|Config/Wezterm/wezterm\.lua|\.github/workflows/.*\.(yml|yaml)|\.llm/.*\.md|AGENTS\.md|CLAUDE\.md|\.github/copilot-instructions\.md|\.github/dependabot\.yml|\.pre-commit-config\.yaml|\.gitattributes|\.editorconfig|\.gitignore|requirements\.txt|\.psscriptanalyzer(\.format)?\.psd1|\.shellcheckrc|\.stylua\.toml|Scripts/Utils/Quality/(native-quality-tools|shell-quality-tools)\.json)$'
+        files: '^(Scripts/Utils/.*\.ps1|Tests/Utils/.*\.Tests\.ps1|Tests/GitHub/.*\.ps1|Config/Powershell/.*\.ps1|Scripts/AutoHotKey/.*\.ahk|Config/\.config/.*\.ahk|Scripts/.*\.bat|Scripts/.*\.sh|\.devcontainer/.*\.sh|\.githooks/(pre-commit|pre-push)|Config/Wezterm/wezterm\.lua|\.github/workflows/.*\.(yml|yaml)|\.llm/.*\.md|AGENTS\.md|CLAUDE\.md|\.github/copilot-instructions\.md|\.github/dependabot\.yml|\.pre-commit-config\.yaml|\.gitattributes|\.editorconfig|\.gitignore|requirements\.txt|\.psscriptanalyzer(\.format)?\.psd1|\.shellcheckrc|\.stylua\.toml|Scripts/Utils/Quality/(native-quality-tools|shell-quality-tools)\.json)$'
         pass_filenames: false
         stages: [pre-commit]
       - id: powershell-prepush-validation

--- a/Config/Powershell/CurrentUserCurrentHost_Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/CurrentUserCurrentHost_Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,24 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
-Set-PSReadLineOption -EditMode Windows
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('EditMode')) {
+    Set-PSReadLineOption -EditMode Windows -ErrorAction SilentlyContinue
+}
+
+$setPSReadLineKeyHandler = Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue
+if ($setPSReadLineKeyHandler) {
+    Set-PSReadLineKeyHandler -Key Tab -Function Complete -ErrorAction SilentlyContinue
+}
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,24 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
-Set-PSReadLineOption -EditMode Windows
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('EditMode')) {
+    Set-PSReadLineOption -EditMode Windows -ErrorAction SilentlyContinue
+}
+
+$setPSReadLineKeyHandler = Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue
+if ($setPSReadLineKeyHandler) {
+    Set-PSReadLineKeyHandler -Key Tab -Function Complete -ErrorAction SilentlyContinue
+}
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/WindowsPowerShellFallback_Microsoft.PowerShell_profile.ps1
+++ b/Config/Powershell/WindowsPowerShellFallback_Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,24 @@
-Import-Module PSReadLine
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
-Set-PSReadLineOption -PredictionViewStyle InLineView
-Set-PSReadLineOption -EditMode Windows
+Import-Module PSReadLine -ErrorAction SilentlyContinue
+
+# -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
+# stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
+if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('EditMode')) {
+    Set-PSReadLineOption -EditMode Windows -ErrorAction SilentlyContinue
+}
+
+$setPSReadLineKeyHandler = Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue
+if ($setPSReadLineKeyHandler) {
+    Set-PSReadLineKeyHandler -Key Tab -Function Complete -ErrorAction SilentlyContinue
+}
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Config/Powershell/profile.ps1
+++ b/Config/Powershell/profile.ps1
@@ -1,20 +1,24 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '', Justification = 'Set-PSReadLineOption -PredictionSource/-PredictionViewStyle are invoked only when a runtime Get-Command capability probe confirms the parameters exist; stock Windows PowerShell 5.1 (PSReadLine 2.0) skips them safely.')]
-param()
-
 Import-Module PSReadLine -ErrorAction SilentlyContinue
 
 # -PredictionSource/-PredictionViewStyle require PSReadLine 2.2+, which is absent from
 # stock Windows PowerShell 5.1. Probe capability before invoking so old PSReadLine no-ops.
 $setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
-if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
     Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
 }
-if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
     Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
 }
 if ($setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('EditMode')) {
     Set-PSReadLineOption -EditMode Windows -ErrorAction SilentlyContinue
 }
-Set-PSReadlineKeyHandler -Key Tab -Function Complete
+
+$setPSReadLineKeyHandler = Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue
+if ($setPSReadLineKeyHandler) {
+    Set-PSReadLineKeyHandler -Key Tab -Function Complete -ErrorAction SilentlyContinue
+}
 
 try { $null = gcm pshazz -ea stop; pshazz init 'default' } catch { }

--- a/Scripts/Powershell/PowershellBackup.ps1
+++ b/Scripts/Powershell/PowershellBackup.ps1
@@ -8,10 +8,49 @@ if (-not (Test-Path -LiteralPath $compatibilityHelpersPath -PathType Leaf)) {
 
 . $compatibilityHelpersPath
 
+$psReadLineProfilePortabilityHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath '../Utils/Common/PSReadLineProfilePortabilityHelpers.ps1'
+if (-not (Test-Path -LiteralPath $psReadLineProfilePortabilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: PSReadLine profile portability helper file not found at '$psReadLineProfilePortabilityHelpersPath' (PSScriptRoot='$PSScriptRoot')."
+}
+
+. $psReadLineProfilePortabilityHelpersPath
+
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath "..") -ErrorAction Stop).Path
 $baseDirectory = (Resolve-Path -LiteralPath (Join-Path -Path $baseDirectory -ChildPath "..") -ErrorAction Stop).Path
 $backupFolder = Join-Path -Path (Join-Path -Path $baseDirectory -ChildPath "Config") -ChildPath "Powershell"
 Push-Location -LiteralPath $baseDirectory
+
+function Assert-PowerShellProfileBackupPortability {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProfileName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $resolvedPath = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    try {
+        $violations = @(Get-PSReadLineProfilePortabilityViolation -Path $resolvedPath)
+    }
+    catch {
+        throw (
+            "E_POWERSHELL_BACKUP_PROFILE_PARSE_FAILED: PowerShell profile '{0}' at '{1}' could not be parsed before backup. error={2}" -f
+            $ProfileName,
+            $resolvedPath,
+            $_.Exception.Message
+        )
+    }
+
+    if ($violations.Count -gt 0) {
+        throw (
+            "E_POWERSHELL_BACKUP_PROFILE_PORTABILITY: PowerShell profile '{0}' at '{1}' contains PSReadLine setup that is not guarded for Windows PowerShell 5.1 and older PSReadLine versions. violations={2}. Restore the repository profile or update the source profile before backup." -f
+            $ProfileName,
+            $resolvedPath,
+            ($violations -join ',')
+        )
+    }
+}
 
 try {
     if (-not (Test-Path -LiteralPath $backupFolder -PathType Container)) {
@@ -61,6 +100,12 @@ try {
                 Name = $candidate.Name
                 Path = $trimmedPath
             })
+    }
+
+    foreach ($candidate in $normalizedCandidates) {
+        if (Test-Path -LiteralPath $candidate.Path -PathType Leaf) {
+            Assert-PowerShellProfileBackupPortability -ProfileName $candidate.Name -Path $candidate.Path
+        }
     }
 
     Write-Verbose (

--- a/Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1
+++ b/Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1
@@ -1,0 +1,614 @@
+# PSReadLineProfilePortabilityHelpers.ps1
+#
+# Shared AST-backed checks for PowerShell profile PSReadLine setup. Profiles are copied
+# from user machines, so backup and CI both need to reject unguarded PSReadLine 2.2+
+# options that break Windows PowerShell 5.1 or redirected hosts.
+
+function Test-PSReadLineAstExtentContainsAst {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$ContainerAst,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$ChildAst
+    )
+
+    return ($ContainerAst.Extent.StartOffset -le $ChildAst.Extent.StartOffset -and
+        $ContainerAst.Extent.EndOffset -ge $ChildAst.Extent.EndOffset)
+}
+
+function Test-PSReadLineAstContainsVariableName {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $matches = @($Ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                $node.VariablePath.UserPath -ieq $Name
+            }, $true))
+
+    return ($matches.Count -gt 0)
+}
+
+function Test-PSReadLineAstContainsStandaloneVariableName {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $matches = @($Ast.FindAll({
+                param($node)
+                if (-not (Test-PSReadLineAstIsVariableName -Ast $node -Name $Name)) {
+                    return $false
+                }
+
+                return (-not ($node.Parent -is [System.Management.Automation.Language.MemberExpressionAst]))
+            }, $true))
+
+    return ($matches.Count -gt 0)
+}
+
+function Test-PSReadLineAstIsVariableName {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    return ($Ast -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $Ast.VariablePath.UserPath -ieq $Name)
+}
+
+function Test-PSReadLineAstIsStringMemberName {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    return ($Ast -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        $Ast.Value -ieq $Name)
+}
+
+function Test-PSReadLineAstIsTypeMemberAccess {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TypeName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MemberName
+    )
+
+    if (-not ($Ast -is [System.Management.Automation.Language.MemberExpressionAst])) {
+        return $false
+    }
+    if (-not ($Ast.Expression -is [System.Management.Automation.Language.TypeExpressionAst])) {
+        return $false
+    }
+    if ($Ast.Expression.TypeName.Name -ine $TypeName -and $Ast.Expression.TypeName.FullName -ine $TypeName) {
+        return $false
+    }
+
+    return (Test-PSReadLineAstIsStringMemberName -Ast $Ast.Member -Name $MemberName)
+}
+
+function Test-PSReadLineAstContainsTypeMemberAccess {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TypeName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MemberName
+    )
+
+    $matches = @($Ast.FindAll({
+                param($node)
+                Test-PSReadLineAstIsTypeMemberAccess -Ast $node -TypeName $TypeName -MemberName $MemberName
+            }, $true))
+
+    return ($matches.Count -gt 0)
+}
+
+function Get-PSReadLineUnwrappedExpressionAst {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.Ast])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $current = $Ast
+    while ($current -is [System.Management.Automation.Language.CommandExpressionAst]) {
+        $current = $current.Expression
+    }
+
+    return $current
+}
+
+function Get-PSReadLineAndExpressionLeafAst {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.Ast[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $expressionAst = Get-PSReadLineUnwrappedExpressionAst -Ast $Ast
+    if ($expressionAst -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+        $expressionAst.Operator -eq [System.Management.Automation.Language.TokenKind]::And) {
+        $leftLeaves = @(Get-PSReadLineAndExpressionLeafAst -Ast $expressionAst.Left)
+        $rightLeaves = @(Get-PSReadLineAndExpressionLeafAst -Ast $expressionAst.Right)
+        return @($leftLeaves + $rightLeaves) # array-unwrap-safe: callers wrap in @(...).
+    }
+
+    return @($expressionAst) # array-unwrap-safe: callers wrap in @(...).
+}
+
+function Test-PSReadLineAstIsFalseLiteral {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $expressionAst = Get-PSReadLineUnwrappedExpressionAst -Ast $Ast
+    return (Test-PSReadLineAstIsVariableName -Ast $expressionAst -Name 'false')
+}
+
+function Test-PSReadLineAstIsHostUISupportsVirtualTerminalProbe {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $expressionAst = Get-PSReadLineUnwrappedExpressionAst -Ast $Ast
+    if ($expressionAst -is [System.Management.Automation.Language.ConvertExpressionAst]) {
+        $expressionAst = $expressionAst.Child
+    }
+
+    return (Test-PSReadLineAstContainsHostUISupportsVirtualTerminalAccess -Ast $expressionAst)
+}
+
+function Test-PSReadLineAstIsSafePredictionHostGuardExpression {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $leaves = @(Get-PSReadLineAndExpressionLeafAst -Ast $Ast)
+    if ($leaves.Count -ne 3) {
+        return $false
+    }
+
+    $matchedUserInteractive = 0
+    $matchedOutputRedirection = 0
+    $matchedVirtualTerminal = 0
+    foreach ($leaf in $leaves) {
+        if (Test-PSReadLineAstIsTypeMemberAccess -Ast $leaf -TypeName 'Environment' -MemberName 'UserInteractive') {
+            $matchedUserInteractive++
+            continue
+        }
+        if ($leaf -is [System.Management.Automation.Language.UnaryExpressionAst] -and
+            $leaf.TokenKind -eq [System.Management.Automation.Language.TokenKind]::Not -and
+            (Test-PSReadLineAstIsTypeMemberAccess -Ast $leaf.Child -TypeName 'Console' -MemberName 'IsOutputRedirected')) {
+            $matchedOutputRedirection++
+            continue
+        }
+        if (Test-PSReadLineAstIsVariableName -Ast $leaf -Name 'supportsVirtualTerminal') {
+            $matchedVirtualTerminal++
+            continue
+        }
+
+        return $false
+    }
+
+    return ($matchedUserInteractive -eq 1 -and $matchedOutputRedirection -eq 1 -and $matchedVirtualTerminal -eq 1)
+}
+
+function Test-PSReadLineAstContainsHostUISupportsVirtualTerminalAccess {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $matches = @($Ast.FindAll({
+                param($node)
+                if (-not ($node -is [System.Management.Automation.Language.MemberExpressionAst])) {
+                    return $false
+                }
+                if (-not (Test-PSReadLineAstIsStringMemberName -Ast $node.Member -Name 'SupportsVirtualTerminal')) {
+                    return $false
+                }
+                if (-not ($node.Expression -is [System.Management.Automation.Language.MemberExpressionAst])) {
+                    return $false
+                }
+
+                $innerMemberAst = $node.Expression
+                return ((Test-PSReadLineAstIsStringMemberName -Ast $innerMemberAst.Member -Name 'UI') -and
+                    (Test-PSReadLineAstIsVariableName -Ast $innerMemberAst.Expression -Name 'Host'))
+            }, $true))
+
+    return ($matches.Count -gt 0)
+}
+
+function Test-PSReadLineAstContainsPSReadLineOptionParameterGuard {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName
+    )
+
+    $matches = @($Ast.FindAll({
+                param($node)
+                if (-not ($node -is [System.Management.Automation.Language.InvokeMemberExpressionAst])) {
+                    return $false
+                }
+                if (-not ($node.Member -is [System.Management.Automation.Language.StringConstantExpressionAst])) {
+                    return $false
+                }
+                if ($node.Member.Value -ne 'ContainsKey') {
+                    return $false
+                }
+                if (-not ($node.Expression -is [System.Management.Automation.Language.MemberExpressionAst])) {
+                    return $false
+                }
+
+                $memberAccessAst = $node.Expression
+                if (-not (Test-PSReadLineAstIsStringMemberName -Ast $memberAccessAst.Member -Name 'Parameters')) {
+                    return $false
+                }
+                if (-not (Test-PSReadLineAstIsVariableName -Ast $memberAccessAst.Expression -Name 'setPSReadLineOption')) {
+                    return $false
+                }
+
+                foreach ($argument in @($node.Arguments)) {
+                    if ($argument -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+                        $argument.Value -eq $ParameterName) {
+                        return $true
+                    }
+                }
+
+                return $false
+            }, $true))
+
+    return ($matches.Count -gt 0)
+}
+
+function Get-PSReadLineAssignmentAstForVariable {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.AssignmentStatementAst[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $assignments = @($Ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                (Test-PSReadLineAstIsVariableName -Ast $node.Left -Name $Name)
+            }, $true))
+
+    return @($assignments) # array-unwrap-safe: callers wrap in @(...).
+}
+
+function Get-PSReadLineAstRoot {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.Ast])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast
+    )
+
+    $current = $Ast
+    while ($null -ne $current.Parent) {
+        $current = $current.Parent
+    }
+
+    return $current
+}
+
+function Test-PSReadLineAstHasSafePredictionHostGuard {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.Ast]$Ast,
+
+        [Parameter(Mandatory = $false)]
+        [int]$BeforeOffset = [int]::MaxValue
+    )
+
+    $hasSupportsVirtualTerminalDefault = $false
+    $hasSupportsVirtualTerminalProbe = $false
+    $sawSupportsVirtualTerminalProbe = $false
+    foreach ($assignment in @(Get-PSReadLineAssignmentAstForVariable -Ast $Ast -Name 'supportsVirtualTerminal')) {
+        if ($assignment.Extent.StartOffset -ge $BeforeOffset) {
+            continue
+        }
+
+        if (Test-PSReadLineAstIsFalseLiteral -Ast $assignment.Right) {
+            $hasSupportsVirtualTerminalDefault = $true
+            continue
+        }
+
+        if (Test-PSReadLineAstIsHostUISupportsVirtualTerminalProbe -Ast $assignment.Right) {
+            $hasSupportsVirtualTerminalProbe = $true
+            $sawSupportsVirtualTerminalProbe = $true
+            continue
+        }
+
+        if ($sawSupportsVirtualTerminalProbe) {
+            return $false
+        }
+    }
+
+    if (-not ($hasSupportsVirtualTerminalDefault -and $hasSupportsVirtualTerminalProbe)) {
+        return $false
+    }
+
+    $lastPredictionGuardAssignment = $null
+    foreach ($assignment in @(Get-PSReadLineAssignmentAstForVariable -Ast $Ast -Name 'canConfigurePSReadLinePrediction')) {
+        if ($assignment.Extent.StartOffset -ge $BeforeOffset) {
+            continue
+        }
+
+        $lastPredictionGuardAssignment = $assignment
+    }
+
+    if ($null -eq $lastPredictionGuardAssignment) {
+        return $false
+    }
+
+    return (Test-PSReadLineAstIsSafePredictionHostGuardExpression -Ast $lastPredictionGuardAssignment.Right)
+}
+
+function Get-PSReadLineGuardConditionAstForCommand {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.Ast[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]$CommandAst
+    )
+
+    $conditions = New-Object System.Collections.Generic.List[System.Management.Automation.Language.Ast]
+    $current = $CommandAst.Parent
+    while ($null -ne $current) {
+        if ($current -is [System.Management.Automation.Language.IfStatementAst]) {
+            foreach ($clause in @($current.Clauses)) {
+                $conditionAst = $clause.Item1
+                $bodyAst = $clause.Item2
+                if ($null -ne $bodyAst -and (Test-PSReadLineAstExtentContainsAst -ContainerAst $bodyAst -ChildAst $CommandAst)) {
+                    $conditions.Add($conditionAst) | Out-Null
+                }
+            }
+        }
+        $current = $current.Parent
+    }
+
+    return @($conditions.ToArray()) # array-unwrap-safe: callers wrap in @(...).
+}
+
+function Test-PSReadLineCommandHasParameter {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]$CommandAst,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName
+    )
+
+    foreach ($element in @($CommandAst.CommandElements)) {
+        if ($element -is [System.Management.Automation.Language.CommandParameterAst] -and
+            $element.ParameterName -ieq $ParameterName) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-PSReadLineCommandGuardedForPredictionParameter {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]$CommandAst,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('PredictionSource', 'PredictionViewStyle')]
+        [string]$ParameterName
+    )
+
+    $rootAst = Get-PSReadLineAstRoot -Ast $CommandAst
+    if (-not (Test-PSReadLineAstHasSafePredictionHostGuard -Ast $rootAst -BeforeOffset $CommandAst.Extent.StartOffset)) {
+        return $false
+    }
+
+    $conditions = @(Get-PSReadLineGuardConditionAstForCommand -CommandAst $CommandAst)
+    if ($conditions.Count -eq 0) {
+        return $false
+    }
+
+    $hasHostGuard = $false
+    $hasCommandProbeGuard = $false
+    $hasParameterGuard = $false
+    foreach ($condition in $conditions) {
+        if (Test-PSReadLineAstContainsStandaloneVariableName -Ast $condition -Name 'canConfigurePSReadLinePrediction') {
+            $hasHostGuard = $true
+        }
+        if (Test-PSReadLineAstContainsStandaloneVariableName -Ast $condition -Name 'setPSReadLineOption') {
+            $hasCommandProbeGuard = $true
+        }
+        if (Test-PSReadLineAstContainsPSReadLineOptionParameterGuard -Ast $condition -ParameterName $ParameterName) {
+            $hasParameterGuard = $true
+        }
+    }
+
+    return ($hasHostGuard -and $hasCommandProbeGuard -and $hasParameterGuard)
+}
+
+function Test-PSReadLineCommandGuardedForKeyHandler {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]$CommandAst
+    )
+
+    $conditions = @(Get-PSReadLineGuardConditionAstForCommand -CommandAst $CommandAst)
+    foreach ($condition in $conditions) {
+        if (Test-PSReadLineAstContainsVariableName -Ast $condition -Name 'setPSReadLineKeyHandler') {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-PSReadLineProfilePortabilityViolation {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
+    if ($parseErrors.Count -gt 0) {
+        $parsePreview = @($parseErrors | Select-Object -First 3 | ForEach-Object { $_.Message }) -join '; '
+        throw "E_PSREADLINE_PROFILE_PARSE_FAILED: Failed to parse PowerShell profile '$Path'. errors=$parsePreview"
+    }
+    if ($null -eq $ast) {
+        return @() # array-unwrap-safe: callers wrap in @(...).
+    }
+
+    $violations = New-Object System.Collections.Generic.List[string]
+    $commandAsts = @($ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst]
+            }, $true))
+
+    foreach ($commandAst in $commandAsts) {
+        $commandName = $commandAst.GetCommandName()
+        if ([string]::IsNullOrWhiteSpace($commandName)) {
+            continue
+        }
+
+        if ($commandName -ieq 'Set-PSReadLineOption') {
+            foreach ($predictionParameterName in @('PredictionSource', 'PredictionViewStyle')) {
+                if (-not (Test-PSReadLineCommandHasParameter -CommandAst $commandAst -ParameterName $predictionParameterName)) {
+                    continue
+                }
+                if (-not (Test-PSReadLineCommandGuardedForPredictionParameter -CommandAst $commandAst -ParameterName $predictionParameterName)) {
+                    $violations.Add("unguarded-$predictionParameterName") | Out-Null
+                }
+            }
+
+            if ($commandAst.Extent.Text -cmatch '\bInLineView\b') {
+                $violations.Add('noncanonical-InLineView') | Out-Null
+            }
+        }
+
+        if ($commandName -ieq 'Set-PSReadLineKeyHandler' -and
+            -not (Test-PSReadLineCommandGuardedForKeyHandler -CommandAst $commandAst)) {
+            $violations.Add('unguarded-Set-PSReadLineKeyHandler') | Out-Null
+        }
+    }
+
+    return @($violations.ToArray()) # array-unwrap-safe: callers wrap in @(...).
+}
+
+function Test-PSReadLineCompatibilityFindingGuarded {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Line,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('PredictionSource', 'PredictionViewStyle')]
+        [string]$ParameterName
+    )
+
+    $parseErrors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
+    if ($null -eq $ast -or $parseErrors.Count -gt 0) {
+        return $false
+    }
+
+    $commandAsts = @($ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst]
+            }, $true))
+
+    foreach ($commandAst in $commandAsts) {
+        $commandName = $commandAst.GetCommandName()
+        if ($commandName -ine 'Set-PSReadLineOption') {
+            continue
+        }
+        if ($commandAst.Extent.StartLineNumber -gt $Line -or $commandAst.Extent.EndLineNumber -lt $Line) {
+            continue
+        }
+        if (-not (Test-PSReadLineCommandHasParameter -CommandAst $commandAst -ParameterName $ParameterName)) {
+            continue
+        }
+
+        return (Test-PSReadLineCommandGuardedForPredictionParameter -CommandAst $commandAst -ParameterName $ParameterName)
+    }
+
+    return $false
+}

--- a/Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1
+++ b/Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1
@@ -289,7 +289,7 @@ function Test-PSReadLineAstContainsPSReadLineOptionParameterGuard {
                 if (-not ($node.Member -is [System.Management.Automation.Language.StringConstantExpressionAst])) {
                     return $false
                 }
-                if ($node.Member.Value -ne 'ContainsKey') {
+                if ($node.Member.Value -ine 'ContainsKey') {
                     return $false
                 }
                 if (-not ($node.Expression -is [System.Management.Automation.Language.MemberExpressionAst])) {
@@ -306,7 +306,7 @@ function Test-PSReadLineAstContainsPSReadLineOptionParameterGuard {
 
                 foreach ($argument in @($node.Arguments)) {
                     if ($argument -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
-                        $argument.Value -eq $ParameterName) {
+                        $argument.Value -ieq $ParameterName) {
                         return $true
                     }
                 }

--- a/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
@@ -9,7 +9,7 @@
     (Core). Any finding that is not a known false positive fails the gate with a stable
     E_COMPAT_INCOMPATIBILITY diagnostic.
 
-    False positives are handled in exactly two sanctioned ways:
+    False positives are handled in these sanctioned ways:
       - Inline [Diagnostics.CodeAnalysis.SuppressMessageAttribute] with a justification,
         for guarded native calls (honored natively by PSScriptAnalyzer).
       - The AllowedCommands list in compatibility-allowlist.psd1, for external

--- a/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
+++ b/Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1
@@ -14,6 +14,8 @@
         for guarded native calls (honored natively by PSScriptAnalyzer).
       - The AllowedCommands list in compatibility-allowlist.psd1, for external
         executables and runtime-installed module commands (for example Pester 5).
+      - Narrow structural filters in shared helpers for repository-owned guarded
+        compatibility idioms that PSScriptAnalyzer cannot model.
 
     This script must itself remain runnable on Windows PowerShell 5.1: no ternary,
     null-coalescing, pipeline-chain operators, $IsWindows/$IsMacOS/$IsLinux references,
@@ -54,6 +56,12 @@ $ErrorActionPreference = 'Stop'
 $scriptRoot = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 # Repo root is three levels up: Scripts/Utils/Quality -> repo root.
 $repositoryRoot = (Resolve-Path -LiteralPath (Join-Path -Path $scriptRoot -ChildPath "../../..")).Path
+$psReadLineProfilePortabilityHelpersPath = Join-Path -Path $scriptRoot -ChildPath "../Common/PSReadLineProfilePortabilityHelpers.ps1"
+if (-not (Test-Path -LiteralPath $psReadLineProfilePortabilityHelpersPath -PathType Leaf)) {
+    throw "E_CONFIG_ERROR: PSReadLine profile portability helper file not found at '$psReadLineProfilePortabilityHelpersPath'."
+}
+
+. $psReadLineProfilePortabilityHelpersPath
 
 if ([string]::IsNullOrWhiteSpace($Path)) {
     $Path = $repositoryRoot
@@ -446,6 +454,24 @@ function Get-FindingCommandName {
     return ''
 }
 
+function Get-FindingParameterName {
+    # Extracts the parameter name from a PSUseCompatibleCommands diagnostic message, which
+    # contains "parameter '<name>'" for parameter-level incompatibilities.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $match = [regex]::Match($Message, "parameter '([^']+)'")
+    if ($match.Success) {
+        return $match.Groups[1].Value
+    }
+
+    return ''
+}
+
 # --- Resolve configuration -------------------------------------------------------------
 
 $allowlistPath = Join-Path -Path $scriptRoot -ChildPath "compatibility-allowlist.psd1"
@@ -516,7 +542,17 @@ foreach ($target in $targets) {
                 $isParameterFinding = $finding.Message.TrimStart().StartsWith('The parameter ')
                 $isModuleCommand = $allowedModuleCommands -contains $commandName
                 $isExternalExecutable = $allowedExternalExecutables -contains $commandName
-                if ($isModuleCommand -or ($isExternalExecutable -and -not $isParameterFinding)) {
+                $parameterName = ''
+                if ($isParameterFinding) {
+                    $parameterName = Get-FindingParameterName -Message $finding.Message
+                }
+                $isGuardedPSReadLinePredictionFinding = $false
+                if ($isParameterFinding -and
+                    $commandName -ieq 'Set-PSReadLineOption' -and
+                    @('PredictionSource', 'PredictionViewStyle') -contains $parameterName) {
+                    $isGuardedPSReadLinePredictionFinding = Test-PSReadLineCompatibilityFindingGuarded -Path $target -Line $finding.Line -ParameterName $parameterName
+                }
+                if ($isModuleCommand -or ($isExternalExecutable -and -not $isParameterFinding) -or $isGuardedPSReadLinePredictionFinding) {
                     $allowedFindingCount = $allowedFindingCount + 1
                     continue
                 }
@@ -578,7 +614,7 @@ if ($OutputFormat -eq 'json') {
     Write-Host "Cross-version compatibility gate (Windows PowerShell 5.1 + PowerShell 7+)"
     Write-Host "  Targets scanned : $($targets.Count)"
     Write-Host "  Profiles        : $([string]::Join(', ', $targetProfiles))"
-    Write-Host "  Allowed (noise) : $allowedFindingCount finding(s) filtered via allowlist/suppression"
+    Write-Host "  Allowed (noise) : $allowedFindingCount finding(s) filtered via allowlist/suppression/structural guards"
     if ($sortedFindings.Count -eq 0) {
         Write-Host "  Result          : PASS - no cross-version incompatibilities detected."
     } else {

--- a/Scripts/Utils/Run-PreCommitValidation.ps1
+++ b/Scripts/Utils/Run-PreCommitValidation.ps1
@@ -1449,10 +1449,22 @@ try {
     elseif ($IncludePreCommitOwnedChecks) {
         $shellQualityFiles = @($stagedFiles | Where-Object { $_ -match $shellQualityPattern })
         $nativeQualityFiles = @($stagedFiles | Where-Object { $_ -match $nativeQualityPattern })
+        $compatibilityTargetFiles = @(
+            $stagedFiles |
+                Where-Object { $_ -match $compatibilityTargetPattern } |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                Sort-Object -Unique
+        )
     }
     else {
         $shellQualityFiles = @()
         $nativeQualityFiles = @()
+        $compatibilityTargetFiles = @(
+            $stagedFiles |
+                Where-Object { $_ -match $compatibilityTargetPattern } |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                Sort-Object -Unique
+        )
     }
     $shellSafetyFiles = @($stagedFiles | Where-Object { $_ -match $shellSafetyTriggerPattern })
     $windowsLanguageFiles = @($stagedFiles | Where-Object { $_ -match $windowsLanguagePattern })
@@ -1505,7 +1517,7 @@ try {
     $runNativeQualityChecks = $All -or $nativeQualityFiles.Count -gt 0
     $runShellSafetySuite = $All -and -not $runUtilsTests
     $runWindowsLanguageChecks = $All -or $windowsLanguageFiles.Count -gt 0
-    $runCompatibilityGate = $All -and $compatibilityTargetFiles.Count -gt 0
+    $runCompatibilityGate = $compatibilityTargetFiles.Count -gt 0
     $runAnalyzer = $analyzerTargets.Count -gt 0
     $runFormatOperatorSafetyCheck = $All -or $scriptFiles.Count -gt 0 -or $utilsTestFiles.Count -gt 0 -or $githubTestFiles.Count -gt 0
     $runLlmHarnessValidation = $All -or $llmHarnessFiles.Count -gt 0
@@ -1853,6 +1865,15 @@ try {
         }
     }
 
+    $requiresPesterModule = $runUtilsTests -or $runGitHubTests -or $runShellSafetySuite
+    $requiresCompatibilityAnalyzerModule = $runCompatibilityGate
+    $requiresLintAnalyzerModule = (-not $SkipAnalyzer) -and $runAnalyzer
+    $requiresScriptAnalyzerModule = $requiresCompatibilityAnalyzerModule -or $requiresLintAnalyzerModule
+    if ($requiresPesterModule -or $requiresScriptAnalyzerModule) {
+        Write-Host "Running PowerShell module prerequisite validation..."
+        Assert-PreCommitPowerShellModuleAvailability -RequirePester:$requiresPesterModule -RequireScriptAnalyzer:$requiresScriptAnalyzerModule
+    }
+
     if ($runCompatibilityGate) {
         $compatibilityGatePath = Join-Path -Path $repoRoot -ChildPath 'Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1'
         if (-not (Test-Path -LiteralPath $compatibilityGatePath -PathType Leaf)) {
@@ -1888,13 +1909,6 @@ try {
         finally {
             Remove-Item -LiteralPath $compatibilityTargetListPath -Force -ErrorAction SilentlyContinue
         }
-    }
-
-    $requiresPesterModule = $runUtilsTests -or $runGitHubTests -or $runShellSafetySuite
-    $requiresScriptAnalyzerModule = (-not $SkipAnalyzer) -and $runAnalyzer
-    if ($requiresPesterModule -or $requiresScriptAnalyzerModule) {
-        Write-Host "Running PowerShell module prerequisite validation..."
-        Assert-PreCommitPowerShellModuleAvailability -RequirePester:$requiresPesterModule -RequireScriptAnalyzer:$requiresScriptAnalyzerModule
     }
 
     if ($runUtilsTests -or $runGitHubTests -or $runShellSafetySuite) {
@@ -1955,7 +1969,7 @@ try {
         if ($null -eq $scriptAnalyzerCommand) {
             $installedScriptAnalyzerVersions = Get-AvailableModuleVersionsText -ModuleName "PSScriptAnalyzer"
             throw (
-                "E_CONFIG_ERROR: Invoke-ScriptAnalyzer from PSScriptAnalyzer {0} or newer is required but unavailable. Installed versions: {1}. Run 'pwsh -NoLogo -NoProfile -File Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules PSScriptAnalyzer' (or install manually with 'Install-Module PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -MinimumVersion {0} -Force') or re-run with -SkipAnalyzer." -f
+                "E_CONFIG_ERROR: Invoke-ScriptAnalyzer from PSScriptAnalyzer {0} or newer is required but unavailable. Installed versions: {1}. Run 'pwsh -NoLogo -NoProfile -File Scripts/Utils/Quality/Install-PowerShellQualityModules.ps1 -Modules PSScriptAnalyzer' (or install manually with 'Install-Module PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -MinimumVersion {0} -Force') or re-run with -SkipAnalyzer to skip only the ScriptAnalyzer lint step; the cross-version compatibility gate still requires PSScriptAnalyzer when PowerShell targets are present." -f
                 $minimumScriptAnalyzerVersion,
                 $installedScriptAnalyzerVersions
             )

--- a/Tests/Utils/CompatibilityConventions.Tests.ps1
+++ b/Tests/Utils/CompatibilityConventions.Tests.ps1
@@ -1,16 +1,63 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+BeforeDiscovery {
+    $compatibilityRepoRootForDiscovery = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    $profileSnapshotCases = @(
+        Get-ChildItem -LiteralPath (Join-Path -Path $compatibilityRepoRootForDiscovery -ChildPath 'Config/Powershell') -Filter '*profile*.ps1' -File |
+            Sort-Object -Property Name |
+            ForEach-Object {
+                @{
+                    RelativePath = ("Config/Powershell/{0}" -f $_.Name)
+                }
+            }
+    )
+    $profileStartupHostCases = @()
+    $profileStartupHostDefinitions = @(
+        @{ HostName = 'PowerShell 7+'; CommandName = 'pwsh' },
+        @{ HostName = 'Windows PowerShell 5.1'; CommandName = 'powershell.exe' }
+    )
+    foreach ($hostDefinition in $profileStartupHostDefinitions) {
+        $hostCommand = Get-Command -Name $hostDefinition.CommandName -ErrorAction SilentlyContinue
+        if ($null -eq $hostCommand) {
+            continue
+        }
+
+        foreach ($profileSnapshotCase in $profileSnapshotCases) {
+            $profileStartupHostCases += @{
+                HostName     = $hostDefinition.HostName
+                CommandPath  = $hostCommand.Source
+                RelativePath = $profileSnapshotCase.RelativePath
+            }
+        }
+    }
+}
+
 BeforeAll {
+    function Resolve-CanonicalTempRoot {
+        param([string]$Path)
+
+        $resolvedItem = Get-Item -LiteralPath $Path -ErrorAction Stop
+        return $resolvedItem.FullName
+    }
+
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
     $script:helperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1"
+    $script:psReadLineProfileHelperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1"
     $script:gatePath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/Invoke-CompatibilityChecks.ps1"
     $script:allowlistPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Quality/compatibility-allowlist.psd1"
+    $script:profileSnapshotCount = @(
+        Get-ChildItem -LiteralPath (Join-Path -Path $script:repoRoot -ChildPath 'Config/Powershell') -Filter '*profile*.ps1' -File
+    ).Count
+    if (Test-Path -LiteralPath $script:psReadLineProfileHelperPath -PathType Leaf) {
+        . $script:psReadLineProfileHelperPath
+    }
 }
 
 Describe "Cross-version compatibility infrastructure" {
     It "ships the keystone compatibility helper, gate, and allowlist" {
         Test-Path -LiteralPath $script:helperPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $script:psReadLineProfileHelperPath -PathType Leaf | Should -BeTrue
         Test-Path -LiteralPath $script:gatePath -PathType Leaf | Should -BeTrue
         Test-Path -LiteralPath $script:allowlistPath -PathType Leaf | Should -BeTrue
     }
@@ -48,24 +95,293 @@ Describe "Cross-version compatibility infrastructure" {
         }
     }
 
-    It "keeps Config PowerShell profile snapshots guarded for PSReadLine prediction options" {
-        $profileSnapshots = @(
-            'Config/Powershell/CurrentUserCurrentHost_Microsoft.PowerShell_profile.ps1',
-            'Config/Powershell/Microsoft.PowerShell_profile.ps1',
-            'Config/Powershell/WindowsPowerShellFallback_Microsoft.PowerShell_profile.ps1'
+    It "discovers Config PowerShell profile files for PSReadLine guard coverage" {
+        $script:profileSnapshotCount | Should -BeGreaterThan 0
+    }
+
+    It "keeps <RelativePath> guarded for PSReadLine capability differences" -TestCases $profileSnapshotCases {
+        param([string]$RelativePath)
+
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath $RelativePath
+        Test-Path -LiteralPath $fullPath -PathType Leaf | Should -BeTrue
+
+        $content = [System.IO.File]::ReadAllText($fullPath, [System.Text.Encoding]::UTF8) -replace "`r", ''
+        $violations = @(Get-PSReadLineProfilePortabilityViolation -Path $fullPath)
+        $violations.Count | Should -Be 0 -Because "$RelativePath PSReadLine setup must be structurally guarded. Violations: $($violations -join ', ')"
+        $content | Should -Match '\$setPSReadLineOption\s*=\s*Get-Command\s+Set-PSReadLineOption' -Because "$RelativePath must probe Set-PSReadLineOption before using version-specific parameters."
+        $content | Should -Match "Parameters\.ContainsKey\('PredictionSource'\)" -Because "$RelativePath must guard PSReadLine 2.2+ prediction source support."
+        $content | Should -Match "Parameters\.ContainsKey\('PredictionViewStyle'\)" -Because "$RelativePath must guard PSReadLine 2.2+ prediction view support."
+        $content | Should -Match '\$canConfigurePSReadLinePrediction\s*=' -Because "$RelativePath must skip prediction setup when the host cannot render it."
+        $content | Should -Match '\[Console\]::IsOutputRedirected' -Because "$RelativePath must skip PSReadLine prediction setup for redirected output."
+        $content | Should -Match '\$Host\.UI\.SupportsVirtualTerminal' -Because "$RelativePath must skip PSReadLine prediction setup when VT rendering is unavailable."
+        $content | Should -Match '\$setPSReadLineKeyHandler\s*=\s*Get-Command\s+Set-PSReadLineKeyHandler' -Because "$RelativePath must not fail profile startup when PSReadLine is unavailable."
+        $content | Should -Not -Match '\[Diagnostics\.CodeAnalysis\.SuppressMessageAttribute\(''PSUseCompatibleCommands''' -Because "$RelativePath must rely on structural guard filtering, not a file-wide compatibility suppression."
+        $content | Should -Not -Match '(?m)(?-i)^\s*Set-PSReadLineOption\s+-PredictionViewStyle\s+InLineView\b'
+    }
+
+    It "classifies synthetic PSReadLine profile guard case: <Name>" -TestCases @(
+        @{
+            Name               = 'valid guarded profile'
+            ExpectedViolations = @()
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
+$setPSReadLineKeyHandler = Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue
+if ($setPSReadLineKeyHandler) { Set-PSReadLineKeyHandler -Key Tab -Function Complete -ErrorAction SilentlyContinue }
+'@
+        }
+        @{
+            Name               = 'unguarded prediction source'
+            ExpectedViolations = @('unguarded-PredictionSource')
+            Content            = @'
+Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+'@
+        }
+        @{
+            Name               = 'wrong parameter guard target'
+            ExpectedViolations = @('unguarded-PredictionSource')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+$other = @{ Parameters = @{} }
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $other.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name               = 'unsafe prediction host guard variable'
+            ExpectedViolations = @('unguarded-PredictionViewStyle')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = $true
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView
+}
+'@
+        }
+        @{
+            Name               = 'unsafe boolean host guard composition'
+            ExpectedViolations = @('unguarded-PredictionSource')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = $true -or ([Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal)
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name               = 'post-probe virtual terminal overwrite'
+            ExpectedViolations = @('unguarded-PredictionViewStyle')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$supportsVirtualTerminal = $true
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView
+}
+'@
+        }
+        @{
+            Name               = 'missing standalone command probe'
+            ExpectedViolations = @('unguarded-PredictionSource')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name               = 'unguarded key handler'
+            ExpectedViolations = @('unguarded-Set-PSReadLineKeyHandler')
+            Content            = @'
+Set-PSReadLineKeyHandler -Key Tab -Function Complete
+'@
+        }
+        @{
+            Name               = 'guard assignment after command'
+            ExpectedViolations = @('unguarded-PredictionSource')
+            Content            = @'
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+'@
+        }
+        @{
+            Name               = 'noncanonical prediction view spelling'
+            ExpectedViolations = @('noncanonical-InLineView')
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InLineView
+}
+'@
+        }
+    ) {
+        param(
+            [string]$Name,
+            [string]$Content,
+            [string[]]$ExpectedViolations
         )
 
-        foreach ($relativePath in $profileSnapshots) {
-            $fullPath = Join-Path -Path $script:repoRoot -ChildPath $relativePath
-            Test-Path -LiteralPath $fullPath -PathType Leaf | Should -BeTrue
+        $tempRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("psreadline-profile-{0}" -f [guid]::NewGuid().ToString('N'))
+        [System.IO.Directory]::CreateDirectory($tempRoot) | Out-Null
+        $tempRoot = Resolve-CanonicalTempRoot -Path $tempRoot
+        $tempPath = Join-Path -Path $tempRoot -ChildPath 'profile.ps1'
+        try {
+            [System.IO.File]::WriteAllText($tempPath, $Content, [System.Text.UTF8Encoding]::new($false))
+            $violations = @(Get-PSReadLineProfilePortabilityViolation -Path $tempPath)
 
-            $content = (Get-Content -LiteralPath $fullPath -Raw) -replace "`r", ''
-            $content | Should -Match '\$setPSReadLineOption\s*=\s*Get-Command\s+Set-PSReadLineOption'
-            $content | Should -Match "Parameters\.ContainsKey\('PredictionSource'\)"
-            $content | Should -Match "Parameters\.ContainsKey\('PredictionViewStyle'\)"
-            $content | Should -Match '\[Diagnostics\.CodeAnalysis\.SuppressMessageAttribute\(''PSUseCompatibleCommands'''
-            $content | Should -Not -Match '(?m)(?-i)^\s*Set-PSReadLineOption\s+-PredictionViewStyle\s+InLineView\b'
+            foreach ($expectedViolation in @($ExpectedViolations)) {
+                $violations | Should -Contain $expectedViolation -Because "$Name should report $expectedViolation."
+            }
+
+            $unexpectedViolations = @(
+                $violations |
+                    Where-Object { @($ExpectedViolations) -notcontains $_ }
+            )
+            $unexpectedViolations.Count | Should -Be 0 -Because "$Name should not report unexpected violations. Actual: $($violations -join ', ')"
         }
+        finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "classifies PSReadLine compatibility finding guard case: <Name>" -TestCases @(
+        @{
+            Name            = 'valid guarded prediction source finding'
+            ParameterName   = 'PredictionSource'
+            ExpectedGuarded = $true
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name            = 'rejects missing standalone command probe'
+            ParameterName   = 'PredictionSource'
+            ExpectedGuarded = $false
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name            = 'rejects unsafe boolean host guard composition'
+            ParameterName   = 'PredictionSource'
+            ExpectedGuarded = $false
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = $true -or ([Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal)
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name            = 'rejects post-probe virtual terminal overwrite'
+            ParameterName   = 'PredictionViewStyle'
+            ExpectedGuarded = $false
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$supportsVirtualTerminal = $true
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionViewStyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView
+}
+'@
+        }
+    ) {
+        param(
+            [string]$Name,
+            [string]$Content,
+            [string]$ParameterName,
+            [bool]$ExpectedGuarded
+        )
+
+        $tempRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("psreadline-compat-finding-{0}" -f [guid]::NewGuid().ToString('N'))
+        [System.IO.Directory]::CreateDirectory($tempRoot) | Out-Null
+        $tempRoot = Resolve-CanonicalTempRoot -Path $tempRoot
+        $tempPath = Join-Path -Path $tempRoot -ChildPath 'profile.ps1'
+        try {
+            [System.IO.File]::WriteAllText($tempPath, $Content, [System.Text.UTF8Encoding]::new($false))
+            $lines = @($Content -split "`r?`n")
+            $commandLine = 0
+            for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+                if ($lines[$lineIndex] -match ('Set-PSReadLineOption\s+-{0}\b' -f [regex]::Escape($ParameterName))) {
+                    $commandLine = $lineIndex + 1
+                    break
+                }
+            }
+
+            $commandLine | Should -BeGreaterThan 0 -Because "$Name must include a Set-PSReadLineOption -$ParameterName command."
+            $guarded = Test-PSReadLineCompatibilityFindingGuarded -Path $tempPath -Line $commandLine -ParameterName $ParameterName
+            $guarded | Should -Be $ExpectedGuarded -Because "$Name should return guarded=$ExpectedGuarded for the compatibility-gate filter."
+        }
+        finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "keeps Config PowerShell profiles quiet when output is redirected under <HostName>: <RelativePath>" -TestCases $profileStartupHostCases {
+        param(
+            [string]$HostName,
+            [string]$CommandPath,
+            [string]$RelativePath
+        )
+
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath $RelativePath
+        $output = @(& $CommandPath -NoLogo -NoProfile -File $fullPath 2>&1)
+        $exitCode = $LASTEXITCODE
+        $psReadLineErrors = @(
+            $output |
+                Where-Object { [string]$_ -match 'predictive suggestion feature cannot be enabled|Set-PSReadLineOption|PredictionSource|PredictionViewStyle' }
+        )
+
+        $exitCode | Should -Be 0 -Because "$RelativePath must not fail in redirected/non-interactive $HostName validation hosts."
+        $psReadLineErrors.Count | Should -Be 0 -Because "$RelativePath must not emit PSReadLine prediction errors under $HostName when output is redirected. Output: $($output -join '; ')"
     }
 }
 
@@ -105,28 +421,31 @@ Describe "Cross-version compatibility - automatic variable scan (dependency-free
     }
 }
 
-Describe "Cross-version compatibility gate (PSScriptAnalyzer)" {
-    It "reports zero cross-version incompatibilities across the repository" {
-        # The full static gate depends on pwsh + PSScriptAnalyzer. When either is unavailable
-        # (for example the runtime-only Windows PowerShell 5.1 test lane) this is covered by
-        # the dedicated powershell-compat-analyzer CI lane instead.
-        if ($null -eq (Get-Command pwsh -ErrorAction SilentlyContinue)) {
-            Set-ItResult -Skipped -Because "pwsh is unavailable; the compat gate is enforced by the powershell-compat-analyzer CI lane."
-            return
-        }
-        $analyzerAvailable = & pwsh -NoProfile -Command "[bool](Get-Module -ListAvailable -Name PSScriptAnalyzer)"
-        if ($analyzerAvailable -ne 'True' -and $analyzerAvailable -ne $true) {
-            Set-ItResult -Skipped -Because "PSScriptAnalyzer is not available; the compat gate is enforced by the powershell-compat-analyzer CI lane."
-            return
-        }
+Describe "Cross-version compatibility gate wiring" {
+    It "keeps the static compatibility rules and diagnostics wired into the gate" {
+        $gateContent = [System.IO.File]::ReadAllText($script:gatePath, [System.Text.Encoding]::UTF8) -replace "`r", ''
 
-        $gateJson = & pwsh -NoProfile -File $script:gatePath -OutputFormat json
-        $gateResult = ($gateJson | Out-String) | ConvertFrom-Json
-        $messages = @($gateResult.findings | ForEach-Object { "$($_.file):$($_.line) [$($_.ruleName)]" })
-        $gateResult.findingCount | Should -Be 0 -Because (
-            "All PowerShell scripts must run on Windows PowerShell 5.1 and PowerShell 7+. Remaining findings: " + ($messages -join '; '))
-        # Sanity check that the allowlist is actually engaged (external exes / Pester DSL).
-        $gateResult.allowedFindingCount | Should -BeGreaterThan 0
+        $gateContent | Should -Match 'PSUseCompatibleSyntax'
+        $gateContent | Should -Match 'PSUseCompatibleCommands'
+        $gateContent | Should -Match 'PSUseCompatibleTypes'
+        $gateContent | Should -Match 'E_COMPAT_INCOMPATIBILITY'
+    }
+
+    It "filters PSReadLine prediction findings only through structural guards" {
+        $gateContent = [System.IO.File]::ReadAllText($script:gatePath, [System.Text.Encoding]::UTF8) -replace "`r", ''
+        $helperContent = [System.IO.File]::ReadAllText($script:psReadLineProfileHelperPath, [System.Text.Encoding]::UTF8) -replace "`r", ''
+
+        $gateContent | Should -Match 'PSReadLineProfilePortabilityHelpers\.ps1'
+        $gateContent | Should -Match 'Get-FindingParameterName'
+        $gateContent | Should -Match 'Test-PSReadLineCompatibilityFindingGuarded'
+        $helperContent | Should -Match 'Get-PSReadLineGuardConditionAstForCommand'
+        $helperContent | Should -Match 'Test-PSReadLineCommandGuardedForPredictionParameter'
+        $helperContent | Should -Match 'Test-PSReadLineAstContainsPSReadLineOptionParameterGuard'
+        $helperContent | Should -Match 'Test-PSReadLineAstHasSafePredictionHostGuard'
+        $helperContent | Should -Match 'Test-PSReadLineAstContainsHostUISupportsVirtualTerminalAccess'
+        $helperContent | Should -Match "ContainsKey"
+        $helperContent | Should -Match "PredictionSource"
+        $helperContent | Should -Match "PredictionViewStyle"
     }
 }
 

--- a/Tests/Utils/CompatibilityConventions.Tests.ps1
+++ b/Tests/Utils/CompatibilityConventions.Tests.ps1
@@ -139,6 +139,22 @@ if ($setPSReadLineKeyHandler) { Set-PSReadLineKeyHandler -Key Tab -Function Comp
 '@
         }
         @{
+            Name               = 'valid guarded profile with case-insensitive PSReadLine guard spelling'
+            ExpectedViolations = @()
+            Content            = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [environment]::UserInteractive -and -not [console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setpsreadlineoption -and $setpsreadlineoption.parameters.containskey('predictionsource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction SilentlyContinue
+}
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.PARAMETERS.CONTAINSKEY('predictionviewstyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView -ErrorAction SilentlyContinue
+}
+'@
+        }
+        @{
             Name               = 'unguarded prediction source'
             ExpectedViolations = @('unguarded-PredictionSource')
             Content            = @'
@@ -287,6 +303,34 @@ $canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Co
 $setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
 if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.Parameters.ContainsKey('PredictionSource')) {
     Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name            = 'valid guarded prediction source finding with case-insensitive guard spelling'
+            ParameterName   = 'PredictionSource'
+            ExpectedGuarded = $true
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [environment]::UserInteractive -and -not [console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setpsreadlineoption -and $setpsreadlineoption.parameters.containskey('predictionsource')) {
+    Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+}
+'@
+        }
+        @{
+            Name            = 'valid guarded prediction view finding with case-insensitive guard spelling'
+            ParameterName   = 'PredictionViewStyle'
+            ExpectedGuarded = $true
+            Content         = @'
+$supportsVirtualTerminal = $false
+try { $supportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $supportsVirtualTerminal = $false }
+$canConfigurePSReadLinePrediction = [Environment]::UserInteractive -and -not [Console]::IsOutputRedirected -and $supportsVirtualTerminal
+$setPSReadLineOption = Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue
+if ($canConfigurePSReadLinePrediction -and $setPSReadLineOption -and $setPSReadLineOption.PARAMETERS.CONTAINSKEY('predictionviewstyle')) {
+    Set-PSReadLineOption -PredictionViewStyle InlineView
 }
 '@
         }

--- a/Tests/Utils/HookTimeout.Tests.ps1
+++ b/Tests/Utils/HookTimeout.Tests.ps1
@@ -5,6 +5,38 @@ BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
     $script:hookTimeoutHelperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/HookTimeout.sh"
     . (Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1")
+
+    function ConvertTo-BashPathForTest {
+        param([string]$Path)
+
+        if (-not (Test-IsWindowsPlatform)) {
+            return $Path
+        }
+
+        $cygpathCommand = Get-Command -Name cygpath -ErrorAction SilentlyContinue
+        if ($null -ne $cygpathCommand) {
+            $global:LASTEXITCODE = 0
+            $convertedPath = @(& $cygpathCommand.Source -u $Path 2>$null | Select-Object -First 1)
+            if ($global:LASTEXITCODE -eq 0 -and $convertedPath.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($convertedPath[0])) {
+                return [string]$convertedPath[0]
+            }
+        }
+
+        $wslCommand = Get-Command -Name wsl.exe -ErrorAction SilentlyContinue
+        if ($null -ne $wslCommand) {
+            $wslInputPath = $Path -replace '\\', '/'
+            $global:LASTEXITCODE = 0
+            $convertedPath = @(& $wslCommand.Source wslpath -a $wslInputPath 2>$null | Select-Object -First 1)
+            if ($global:LASTEXITCODE -eq 0 -and $convertedPath.Count -gt 0) {
+                $convertedPathText = [string]$convertedPath[0]
+                if (-not [string]::IsNullOrWhiteSpace($convertedPathText) -and $convertedPathText.StartsWith('/')) {
+                    return $convertedPathText
+                }
+            }
+        }
+
+        return $null
+    }
 }
 
 Describe "HookTimeout shell watchdog behavior" {
@@ -41,6 +73,13 @@ printf '%s\n' "stdout-data"
 
         $process = $null
         try {
+            $driverPathForBash = ConvertTo-BashPathForTest -Path $driverPath
+            $helperPathForBash = ConvertTo-BashPathForTest -Path $script:hookTimeoutHelperPath
+            if ([string]::IsNullOrWhiteSpace($driverPathForBash) -or [string]::IsNullOrWhiteSpace($helperPathForBash)) {
+                Set-ItResult -Skipped -Because "bash is available, but no Windows-to-bash path converter is available."
+                return
+            }
+
             $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
             $startInfo.FileName = $bashCommand.Source
             $startInfo.RedirectStandardOutput = $true
@@ -48,8 +87,8 @@ printf '%s\n' "stdout-data"
             $startInfo.UseShellExecute = $false
             $startInfo.CreateNoWindow = $true
             Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList @(
-                $driverPath,
-                $script:hookTimeoutHelperPath
+                $driverPathForBash,
+                $helperPathForBash
             )
 
             $process = [System.Diagnostics.Process]::new()

--- a/Tests/Utils/PreCommitPrePushValidationHook.Tests.ps1
+++ b/Tests/Utils/PreCommitPrePushValidationHook.Tests.ps1
@@ -3,6 +3,64 @@ $ErrorActionPreference = "Stop"
 
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../..")).Path
+    . (Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CompatibilityHelpers.ps1")
+
+    function Invoke-GitStdoutForHookTest {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$GitPath,
+
+            [Parameter(Mandatory = $true)]
+            [string[]]$Arguments
+        )
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $GitPath
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        Set-PortableProcessArguments -StartInfo $startInfo -ArgumentList $Arguments
+
+        $process = [System.Diagnostics.Process]::new()
+        try {
+            $process.StartInfo = $startInfo
+            $process.Start() | Out-Null
+            if (-not $process.WaitForExit(30000)) {
+                Stop-ProcessTreePortably -Process $process
+                throw "git command exceeded 30s. args=$($Arguments -join ' ')"
+            }
+
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            if ($process.ExitCode -ne 0) {
+                throw "git command failed (exitCode=$($process.ExitCode); args=$($Arguments -join ' '); stderr=$stderr)"
+            }
+
+            return @(
+                $stdout -split '\r?\n' |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+        }
+        finally {
+            $process.Dispose()
+        }
+    }
+
+    function Test-IsWindowsNativeBashForHookTest {
+        param([string]$BashPath)
+
+        if ([System.IO.Path]::DirectorySeparatorChar -ne '\') {
+            return $true
+        }
+
+        $unameOutput = @(& $BashPath --noprofile --norc -c 'uname -s' 2>$null | Select-Object -First 1)
+        if ($LASTEXITCODE -ne 0 -or $unameOutput.Count -eq 0) {
+            return $false
+        }
+
+        return ([string]$unameOutput[0] -match '^(MINGW|MSYS|CYGWIN)')
+    }
 }
 
 Describe "powershell pre-push pre-commit validation hook" {
@@ -141,6 +199,10 @@ Describe "powershell pre-push pre-commit validation hook" {
         $bashCommand = Get-Command -Name "bash" -ErrorAction SilentlyContinue
         if ($null -eq $bashCommand) {
             Set-ItResult -Skipped -Because "bash is unavailable."
+            return
+        }
+        if (-not (Test-IsWindowsNativeBashForHookTest -BashPath $bashCommand.Source)) {
+            Set-ItResult -Skipped -Because "bash is not Windows-native; WSL bash cannot reliably execute the Windows worktree hook in this test."
             return
         }
 
@@ -313,11 +375,8 @@ exec "$($gitCommand.Source)" "`$@"
                 ($readTreeOutput -join "`n")
             )
 
-            $modifiedFiles = @(& $gitCommand.Source -C $script:repoRoot diff --name-only 2>$null)
-            $LASTEXITCODE | Should -Be 0 -Because "temp-index modified-file discovery should succeed."
-
-            $untrackedFiles = @(& $gitCommand.Source -C $script:repoRoot ls-files --others --exclude-standard 2>$null)
-            $LASTEXITCODE | Should -Be 0 -Because "temp-index untracked-file discovery should succeed."
+            $modifiedFiles = @(Invoke-GitStdoutForHookTest -GitPath $gitCommand.Source -Arguments @("-C", $script:repoRoot, "diff", "--name-only"))
+            $untrackedFiles = @(Invoke-GitStdoutForHookTest -GitPath $gitCommand.Source -Arguments @("-C", $script:repoRoot, "ls-files", "--others", "--exclude-standard"))
 
             $filesToStage = @(
                 $modifiedFiles + $untrackedFiles |

--- a/Tests/Utils/Run-PreCommitValidation.FastLocal.Tests.ps1
+++ b/Tests/Utils/Run-PreCommitValidation.FastLocal.Tests.ps1
@@ -64,15 +64,23 @@ Describe "Run-PreCommitValidation fast local mode" {
         $script:preCommitContent | Should -Match 'Invoke-PesterQualityGateInIsolatedProcess'
     }
 
-    It "keeps cross-version compatibility checks in all-mode deep validation" {
+    It "runs cross-version compatibility checks for targeted PowerShell files without enabling Pester fast-lane work" {
         $script:preCommitContent | Should -Match '\$compatibilityTargetFiles\s*=\s*@\(\s*\$trackedFileOutput[\s\S]*?\$compatibilityTargetPattern'
-        $script:preCommitContent | Should -Match '\$runCompatibilityGate\s*=\s*\$All\s+-and\s+\$compatibilityTargetFiles\.Count\s+-gt\s+0'
-        $script:preCommitContent | Should -Not -Match '\$runCompatibilityGate\s*=\s*-not\s+\$All'
+        $script:preCommitContent | Should -Match '\$stagedFiles[\s\S]*?\$compatibilityTargetPattern[\s\S]*?Test-Path\s+-LiteralPath\s+\$_\s+-PathType\s+Leaf'
+        $script:preCommitContent | Should -Match '\$runCompatibilityGate\s*=\s*\$compatibilityTargetFiles\.Count\s+-gt\s+0'
+        $script:preCommitContent | Should -Match '\$requiresCompatibilityAnalyzerModule\s*=\s*\$runCompatibilityGate'
+        $script:preCommitContent | Should -Match '\$requiresLintAnalyzerModule\s*=\s*\(-not\s+\$SkipAnalyzer\)\s+-and\s+\$runAnalyzer'
+        $script:preCommitContent | Should -Match '\$requiresScriptAnalyzerModule\s*=\s*\$requiresCompatibilityAnalyzerModule\s+-or\s+\$requiresLintAnalyzerModule'
+        $script:preCommitContent | Should -Match 'SkipAnalyzer to skip only the ScriptAnalyzer lint step'
+        $script:preCommitContent.IndexOf('$requiresCompatibilityAnalyzerModule = $runCompatibilityGate') | Should -BeLessThan $script:preCommitContent.IndexOf('if ($runCompatibilityGate)')
         $script:preCommitContent | Should -Match 'Invoke-CompatibilityChecks\.ps1'
+        $script:preCommitContent | Should -Match 'Running cross-version compatibility gate for \{0\} staged target\(s\)'
     }
 
     It "keeps shell and native quality checks as all-mode-only orchestrator work" {
-        $script:preCommitContent | Should -Match '(?s)if\s*\(\$All\)\s*\{.*?\$shellQualityFiles\s*=.*?\$nativeQualityFiles\s*=.*?\}\s*elseif\s*\(\$IncludePreCommitOwnedChecks\)\s*\{.*?\$shellQualityFiles\s*=.*?\$nativeQualityFiles\s*=.*?\}\s*else\s*\{\s*\$shellQualityFiles\s*=\s*@\(\)\s*\$nativeQualityFiles\s*=\s*@\(\)\s*\}'
+        $script:preCommitContent | Should -Match '(?s)if\s*\(\$All\)\s*\{.*?\$shellQualityFiles\s*=.*?\$nativeQualityFiles\s*='
+        $script:preCommitContent | Should -Match '(?s)elseif\s*\(\$IncludePreCommitOwnedChecks\)\s*\{.*?\$shellQualityFiles\s*=.*?\$nativeQualityFiles\s*='
+        $script:preCommitContent | Should -Match '(?s)else\s*\{.*?\$shellQualityFiles\s*=\s*@\(\).*?\$nativeQualityFiles\s*=\s*@\(\)'
         $script:preCommitContent | Should -Match '\$runShellQualityChecks\s*=\s*\$All\s+-or\s+\$shellQualityFiles\.Count\s+-gt\s+0'
         $script:preCommitContent | Should -Match '\$runNativeQualityChecks\s*=\s*\$All\s+-or\s+\$nativeQualityFiles\.Count\s+-gt\s+0'
         $script:preCommitContent | Should -Match 'Invoke-ShellQualityChecks\.ps1'

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -786,6 +786,11 @@ Describe "CI scope expansion" {
         $workflow | Should -Match 'Run Pester suite under PowerShell 7\+[\s\S]*Invoke-PesterQualityGate\.ps1[\s\S]*-OutputVerbosity\s+None[\s\S]*-TestResultOutputPath\s+"testresults-pwsh7\.xml"'
         $workflow | Should -Match 'Windows PowerShell 5\.1 Pester duration: \$elapsedSeconds seconds'
         $workflow | Should -Match 'PowerShell 7\+ Pester duration: \$elapsedSeconds seconds'
+        $workflow | Should -Match 'Install Pester 5 \(Windows PowerShell 5\.1\)[\s\S]*Install-PowerShellQualityModules\.ps1 -Modules Pester'
+        $workflow | Should -Match 'Install Pester 5 \(PowerShell 7\+\)[\s\S]*Install-PowerShellQualityModules\.ps1 -Modules Pester'
+        $workflow | Should -Match 'powershell-compat-analyzer:[\s\S]*Install-PowerShellQualityModules\.ps1 -Modules PSScriptAnalyzer'
+        $workflow | Should -Not -Match 'Install Pester 5[^\r\n]*PSScriptAnalyzer'
+        $workflow | Should -Not -Match 'Install-PowerShellQualityModules\.ps1 -Modules Pester,PSScriptAnalyzer'
     }
 
     It "keeps each Pester XML artifact upload bound to its own always-run step" {
@@ -948,7 +953,9 @@ Describe "Cross-language quality platform conventions" {
 
         $preCommitConfig | Should -Match 'id:\s+powershell-format[\s\S]*stages:\s+\[pre-commit\]'
         $preCommitConfig | Should -Match 'id:\s+powershell-precommit-validation'
+        $preCommitConfig | Should -Match 'id:\s+powershell-format[\s\S]*files:\s+''\^\(Scripts\|Tests\|Config/Powershell\)/\.\*\\\.ps1\$'''
         $powershellPreCommitHookBlock = Get-PreCommitHookBlock -ConfigContent $preCommitConfig -HookId "powershell-precommit-validation"
+        $powershellPreCommitHookBlock | Should -Match ([regex]::Escape('Config/Powershell/.*\.ps1'))
         $powershellPreCommitHookBlock | Should -Match ([regex]::Escape('\.pre-commit-config\.yaml'))
         $powershellPreCommitHookBlock | Should -Match ([regex]::Escape('\.gitattributes'))
         $powershellPreCommitHookBlock | Should -Match ([regex]::Escape('\.editorconfig'))
@@ -1109,13 +1116,18 @@ Describe "Cross-language quality platform conventions" {
         $validatorContent | Should -Match 'Running Windows language static validation'
     }
 
-    It "runs cross-version compatibility checks only through the deep precommit orchestrator mode" {
+    It "runs cross-version compatibility checks in deep mode and for staged PowerShell targets" {
         $validatorPath = Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Utils/Run-PreCommitValidation.ps1'
         $validatorContent = Get-Content -Path $validatorPath -Raw
 
         $validatorContent | Should -Match '\$compatibilityTargetPattern\s*='
-        $validatorContent | Should -Match '\$runCompatibilityGate\s*=\s*\$All\s+-and\s+\$compatibilityTargetFiles\.Count\s+-gt\s+0'
-        $validatorContent | Should -Not -Match '\$runCompatibilityGate\s*=\s*-not\s+\$All'
+        $validatorContent | Should -Match 'Where-Object\s+\{\s+\$_\s+-match\s+\$compatibilityTargetPattern\s+\}'
+        $validatorContent | Should -Match '\$runCompatibilityGate\s*=\s*\$compatibilityTargetFiles\.Count\s+-gt\s+0'
+        $validatorContent | Should -Match '\$requiresCompatibilityAnalyzerModule\s*=\s*\$runCompatibilityGate'
+        $validatorContent | Should -Match '\$requiresLintAnalyzerModule\s*=\s*\(-not\s+\$SkipAnalyzer\)\s+-and\s+\$runAnalyzer'
+        $validatorContent | Should -Match '\$requiresScriptAnalyzerModule\s*=\s*\$requiresCompatibilityAnalyzerModule\s+-or\s+\$requiresLintAnalyzerModule'
+        $validatorContent | Should -Match 'SkipAnalyzer to skip only the ScriptAnalyzer lint step'
+        $validatorContent.IndexOf('$requiresCompatibilityAnalyzerModule = $runCompatibilityGate') | Should -BeLessThan $validatorContent.IndexOf('if ($runCompatibilityGate)')
         $validatorContent | Should -Match 'Invoke-CompatibilityChecks\.ps1'
         $validatorContent | Should -Match 'Running cross-version compatibility gate for'
         $validatorContent | Should -Match 'E_PRECOMMIT_COMPATIBILITY_FAILED'
@@ -1913,9 +1925,13 @@ Describe "Quality script executable guardrails" {
                 }
             }
             elseif (Get-Command -Name wsl.exe -ErrorAction SilentlyContinue) {
-                $convertedPath = @(& wsl.exe wslpath -a $macChecksPath 2>$null | Select-Object -First 1)
-                if ($global:LASTEXITCODE -eq 0 -and $convertedPath.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($convertedPath[0])) {
-                    $bashPathArgument = [string]$convertedPath[0]
+                $wslInputPath = $macChecksPath -replace '\\', '/'
+                $convertedPath = @(& wsl.exe wslpath -a $wslInputPath 2>$null | Select-Object -First 1)
+                if ($global:LASTEXITCODE -eq 0 -and $convertedPath.Count -gt 0) {
+                    $convertedPathText = [string]$convertedPath[0]
+                    if (-not [string]::IsNullOrWhiteSpace($convertedPathText) -and $convertedPathText.StartsWith('/')) {
+                        $bashPathArgument = $convertedPathText
+                    }
                 }
             }
 
@@ -3039,6 +3055,7 @@ Describe "Backup script safety conventions" {
 
     It "uses profile-driven path-safe backup and fails when no PowerShell profiles are available" {
         $powershellBackup = (Get-Content -Path (Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Powershell/PowershellBackup.ps1') -Raw) -replace "`r", ''
+        $psReadLineHelper = (Get-Content -Path (Join-Path -Path $script:repoRoot -ChildPath 'Scripts/Utils/Common/PSReadLineProfilePortabilityHelpers.ps1') -Raw) -replace "`r", ''
 
         $powershellBackup | Should -Match 'Join-Path\s+-Path\s+\(Join-Path\s+-Path\s+\$baseDirectory\s+-ChildPath\s+"Config"\)\s+-ChildPath\s+"Powershell"'
         $powershellBackup | Should -Match '\$PROFILE\.CurrentUserCurrentHost'
@@ -3051,6 +3068,20 @@ Describe "Backup script safety conventions" {
         $powershellBackup | Should -Match 'Copy-Item\s+-LiteralPath\s+\$candidate\.Path\s+-Destination\s+\$canonicalBackupFile\s+-Force'
         $powershellBackup | Should -Match 'PowerShell canonical backup diagnostics:'
         $powershellBackup | Should -Match 'PowerShell backup output diagnostics:'
+        $powershellBackup | Should -Match 'function\s+Assert-PowerShellProfileBackupPortability'
+        $powershellBackup | Should -Match 'E_POWERSHELL_BACKUP_PROFILE_PORTABILITY'
+        $powershellBackup | Should -Match 'E_POWERSHELL_BACKUP_PROFILE_PARSE_FAILED'
+        $powershellBackup | Should -Match 'Assert-PowerShellProfileBackupPortability\s+-ProfileName\s+\$candidate\.Name\s+-Path\s+\$candidate\.Path'
+        $powershellBackup | Should -Match 'PSReadLineProfilePortabilityHelpers\.ps1'
+        $powershellBackup | Should -Match 'Get-PSReadLineProfilePortabilityViolation\s+-Path\s+\$resolvedPath'
+        $psReadLineHelper | Should -Match '\[System\.Management\.Automation\.Language\.Parser\]::ParseFile'
+        $psReadLineHelper | Should -Match 'CommandAst'
+        $psReadLineHelper | Should -Match 'Get-PSReadLineGuardConditionAstForCommand'
+        $psReadLineHelper | Should -Match 'Test-PSReadLineAstContainsPSReadLineOptionParameterGuard'
+        $psReadLineHelper | Should -Match 'Test-PSReadLineAstHasSafePredictionHostGuard'
+        $psReadLineHelper | Should -Match 'Test-PSReadLineAstContainsHostUISupportsVirtualTerminalAccess'
+        $psReadLineHelper | Should -Match 'Test-PSReadLineCompatibilityFindingGuarded'
+        $psReadLineHelper | Should -Match 'E_PSREADLINE_PROFILE_PARSE_FAILED'
         $powershellBackup | Should -Not -Match '\$backupFolder\s*=\s*"\$baseDirectory\\Config\\Powershell"'
         $powershellBackup | Should -Not -Match '\$HOME\\Documents\\PowerShell'
         $powershellBackup | Should -Not -Match '\$HOME\\Documents\\WindowsPowerShell'


### PR DESCRIPTION
## Summary

This PR improves PowerShell profile portability and script-quality checks so profile backup and validation are more reliable across Windows PowerShell 5.1 and PowerShell 7+.

## User-Facing Changes

- PowerShell profile backup now blocks known non-portable PSReadLine prediction setup before copying profiles, with clear diagnostics.
- Tracked PowerShell profiles now enable PSReadLine prediction features only when the host and installed PSReadLine version support them, reducing startup errors in older or redirected consoles.
- Pre-commit now includes Config/Powershell profile files in formatting and validation scope.
- Compatibility checks now recognize properly guarded PSReadLine prediction configuration, reducing false positives while keeping cross-version safety checks strict.
- Script-quality CI test jobs now install only the required test module (Pester), reducing unnecessary setup work.

## Validation

- Updated automated tests for compatibility rules, hook behavior, pre-commit validation, and script safety conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches developer shell startup (profiles), pre-commit gating, and a large new AST policy module; behavior changes are mostly additive guards but mis-detection could block backup or fail compat checks.
> 
> **Overview**
> **Hardens PowerShell profile portability** across Windows PowerShell 5.1 and PowerShell 7+ by guarding PSReadLine prediction/key-handler setup in tracked `Config/Powershell` profiles (host/interactive/VT probes, parameter capability checks) and dropping file-wide compatibility suppressions in favor of structural guards.
> 
> Adds **`PSReadLineProfilePortabilityHelpers.ps1`** (AST checks) used by **`PowershellBackup.ps1`** to block copying unguarded profiles, by **`Invoke-CompatibilityChecks.ps1`** to treat properly guarded `Set-PSReadLineOption` prediction findings as allowed noise, and by expanded **Pester** coverage (profile snapshots, synthetic cases, redirected-host startup).
> 
> **Pre-commit / CI:** `Config/Powershell` is in format and validation hooks; the cross-version compat gate runs for **staged** PowerShell targets (not only `-All`), with separate PSScriptAnalyzer needs for compat vs lint (`-SkipAnalyzer` clarified). Pester CI jobs install **Pester only**; compat analyzer stays on its own lane.
> 
> **Docs:** cross-platform PowerShell guidance now requires 5.1+7+ and `Test-Is*Platform` helpers instead of `$IsWindows` et al. Minor test fixes for Windows bash/git path handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48b81a0076f073dbebdeb37ef084284733b1cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->