### PR TITLE
GitHub Extension Reliability

### DIFF
--- a/.llm/skill-details/github-pr-unresolved-comments.md
+++ b/.llm/skill-details/github-pr-unresolved-comments.md
@@ -147,6 +147,31 @@ surface for the same GitHub PR comment extraction contracts.
   unavailable. Keep record creation and text rendering on one shared renderable
   comment predicate so placeholder-only unavailable suggestions do not become
   `No review comments found.`.
+- Keep extension suggested-change acquisition ordered by trust: extract API
+  ` ```suggestion ` fences first as `source: apiMarkdownSuggestion`,
+  `confidence: high`; then enrich only `github.com` records from GitHub web PR
+  `/files` HTML, trying public HTML, sanitized-cookie HTML, and finally the
+  opt-in browser HTML provider. The browser provider is configured only through
+  the application-scoped user/global
+  `wallstopPrComments.browserWebSuggestionsCommand` setting
+  (`.inspect(...).globalValue`; ignore workspace values), receives the PR
+  `/files` URL, and must return an HTML string or `{ html: string }`.
+- Trust web/browser suggested diffs only when parsed from
+  `comment.automatedComment.suggestion.diffEntries`, keyed by comment
+  `databaseId` or discussion URL. Reject lookalike JSON embedded in
+  user-authored `body` fields and sibling `suggestion.diffEntries` without
+  `automatedComment` provenance; expose only `DELETION`/`ADDITION` lines,
+  prefix every physical line after CR/LF normalization, label cross-path diffs
+  as `Suggested change (<path>):`, and retain `source`/`confidence`
+  (`githubWebAutomatedDiff` or `browserDomAutomatedDiff`, `medium`).
+- Keep extension Cursor/Bugbot handling conservative: external fixes not exposed
+  by GitHub remain unavailable records (`unavailableSource:
+  externalBotUnavailable`, `unavailableConfidence: unavailable`) instead of fake
+  suggested diffs; embedded `LOCATIONS` are trusted only from normalized exact
+  bot logins `cursor[bot]`, `cursor-bugbot[bot]`, or `bugbot[bot]`. Same-path
+  embedded ranges may override file-anchored review ranges, mismatched embedded
+  paths must not override file-anchored threads, and conversation-level bot
+  comments may use the first embedded location.
 - Keep extension UI state resilient: persisted repository lists are untrusted
   input and must be shape-checked/sanitized on read, skipping invalid entries
   instead of throwing from tree/sidebar code.

--- a/.llm/skill-details/github-pr-unresolved-comments.md
+++ b/.llm/skill-details/github-pr-unresolved-comments.md
@@ -162,13 +162,18 @@ surface for the same GitHub PR comment extraction contracts.
   user-authored `body` fields and sibling `suggestion.diffEntries` without
   `automatedComment` provenance; expose only `DELETION`/`ADDITION` lines,
   prefix every physical line after CR/LF normalization, label cross-path diffs
-  as `Suggested change (<path>):`, and retain `source`/`confidence`
-  (`githubWebAutomatedDiff` or `browserDomAutomatedDiff`, `medium`).
+  as `Suggested change (<path>):`, deduplicate by normalized path plus public
+  changed-line text, and retain `source`/`confidence` (`githubWebAutomatedDiff`
+  or `browserDomAutomatedDiff`, `medium`).
 - Keep extension Cursor/Bugbot handling conservative: external fixes not exposed
   by GitHub remain unavailable records (`unavailableSource:
   externalBotUnavailable`, `unavailableConfidence: unavailable`) instead of fake
-  suggested diffs; embedded `LOCATIONS` are trusted only from normalized exact
-  bot logins `cursor[bot]`, `cursor-bugbot[bot]`, or `bugbot[bot]`. Same-path
+  suggested diffs; Copilot/GitHub web-only unavailable suggestions use
+  `unavailableSource: webOnlyUnavailable`; unavailable classification requires a
+  trusted exact bot identity plus a generated/web-suggestion marker, never broad
+  substring/word-boundary login matching or marker text alone. Embedded
+  `LOCATIONS` are trusted only from normalized exact bot logins `cursor[bot]`,
+  `cursor-bugbot[bot]`, or `bugbot[bot]`. Same-path
   embedded ranges may override file-anchored review ranges, mismatched embedded
   paths must not override file-anchored threads, and conversation-level bot
   comments may use the first embedded location.

--- a/Extensions/WallstopPrComments/package.json
+++ b/Extensions/WallstopPrComments/package.json
@@ -132,6 +132,12 @@
           ],
           "default": "unresolved",
           "description": "Default review-comment scope used when copying PR comments."
+        },
+        "wallstopPrComments.browserWebSuggestionsCommand": {
+          "type": "string",
+          "scope": "application",
+          "default": "",
+          "description": "Optional VS Code command that returns logged-in GitHub PR files HTML for a supplied URL. Used only for browser/session-backed suggested-change extraction."
         }
       }
     }

--- a/Extensions/WallstopPrComments/src/botAuthors.ts
+++ b/Extensions/WallstopPrComments/src/botAuthors.ts
@@ -1,0 +1,21 @@
+const cursorBugbotAuthorLogins = new Set([
+  'bugbot[bot]',
+  'cursor-bugbot[bot]',
+  'cursor[bot]',
+]);
+
+export function isCursorBugbotAuthor(authorLogin: string | undefined): boolean {
+  const normalized = normalizeAuthorLogin(authorLogin);
+  return normalized !== undefined && cursorBugbotAuthorLogins.has(normalized);
+}
+
+export function isCopilotPullRequestReviewerAuthor(authorLogin: string | undefined): boolean {
+  const normalized = normalizeAuthorLogin(authorLogin);
+  return normalized === 'copilot-pull-request-reviewer' ||
+    normalized === 'copilot-pull-request-reviewer[bot]';
+}
+
+function normalizeAuthorLogin(authorLogin: string | undefined): string | undefined {
+  const normalized = authorLogin?.trim().toLowerCase();
+  return normalized === '' ? undefined : normalized;
+}

--- a/Extensions/WallstopPrComments/src/extension.ts
+++ b/Extensions/WallstopPrComments/src/extension.ts
@@ -199,7 +199,7 @@ export async function getBrowserWebSuggestionsHtml(url: string): Promise<string 
     return result.html;
   }
 
-  throw new Error(`Browser web suggestions command '${command}' must return an HTML string.`);
+  throw new Error(`Browser web suggestions command '${command}' must return an HTML string or { html: string }.`);
 }
 
 function getBrowserWebSuggestionsCommand(): string | undefined {

--- a/Extensions/WallstopPrComments/src/extension.ts
+++ b/Extensions/WallstopPrComments/src/extension.ts
@@ -29,6 +29,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const client = new GitHubClient({
     getToken: (host, createIfNone) => auth.getToken(host, createIfNone),
     getWebCookie: (host) => auth.getWebCookie(host),
+    browserWebHtmlProvider: (url) => getBrowserWebSuggestionsHtml(url),
   });
   const provider = new PrCommentsTreeProvider(store, client);
 
@@ -156,11 +157,13 @@ async function copyReviewComments(
 
     const records = result.threads.map(reviewThreadToRecord).filter(isReviewThreadRecord);
     try {
-      const webDiffs = await client.getWebSuggestedDiffs(repository, prNumber);
-      if (webDiffs.size > 0) {
-        const attached = attachWebSuggestedDiffs(records, webDiffs);
+      const webDiffs = await client.getWebSuggestedDiffs(repository, prNumber, {
+        allowBrowserFallback: getBrowserWebSuggestionsCommand() !== undefined,
+      });
+      if (webDiffs.suggestions.size > 0) {
+        const attached = attachWebSuggestedDiffs(records, webDiffs.suggestions);
         if (attached > 0) {
-          result.warnings.push(`Attached ${attached} GitHub web suggested change diff(s).`);
+          result.warnings.push(`Attached ${attached} suggested change diff(s) from ${webDiffs.provenance}.`);
         }
       }
     } catch (error) {
@@ -179,6 +182,33 @@ async function copyReviewComments(
   } catch (error) {
     await showError(error);
   }
+}
+
+export async function getBrowserWebSuggestionsHtml(url: string): Promise<string | undefined> {
+  const command = getBrowserWebSuggestionsCommand();
+  if (command === undefined) {
+    return undefined;
+  }
+
+  const result = await vscode.commands.executeCommand<unknown>(command, url);
+  if (typeof result === 'string') {
+    return result;
+  }
+
+  if (isRecord(result) && typeof result.html === 'string') {
+    return result.html;
+  }
+
+  throw new Error(`Browser web suggestions command '${command}' must return an HTML string.`);
+}
+
+function getBrowserWebSuggestionsCommand(): string | undefined {
+  const command = vscode.workspace
+    .getConfiguration('wallstopPrComments')
+    .inspect<string>('browserWebSuggestionsCommand')
+    ?.globalValue
+    ?.trim();
+  return command === '' ? undefined : command;
 }
 
 function getCurrentScope(context: vscode.ExtensionContext): ReviewScope {
@@ -246,4 +276,8 @@ async function showError(error: unknown): Promise<void> {
 
 function isReviewThreadRecord(record: ReviewThreadRecord | undefined): record is ReviewThreadRecord {
   return record !== undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/Extensions/WallstopPrComments/src/githubClient.ts
+++ b/Extensions/WallstopPrComments/src/githubClient.ts
@@ -233,7 +233,7 @@ export class GitHubClient {
     options: WebSuggestionRequestOptions = {},
   ): Promise<WebSuggestedDiffResult> {
     if (repository.host.toLowerCase() !== 'github.com') {
-      return { suggestions: new Map(), provenance: 'externalBotUnavailable' };
+      return { suggestions: new Map(), provenance: 'webOnlyUnavailable' };
     }
 
     const url = `https://github.com/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pull/${prNumber}/files`;
@@ -275,7 +275,7 @@ export class GitHubClient {
       throw privateFetchError;
     }
 
-    return { suggestions: new Map(), provenance: 'externalBotUnavailable' };
+    return { suggestions: new Map(), provenance: 'webOnlyUnavailable' };
   }
 
   private async fetchGitHubWebHtml(

--- a/Extensions/WallstopPrComments/src/githubClient.ts
+++ b/Extensions/WallstopPrComments/src/githubClient.ts
@@ -9,17 +9,22 @@ import type {
   ReviewScope,
   ReviewThread,
   ReviewThreadResult,
-  SuggestedDiff,
+  WebSuggestedDiffResult,
 } from './types';
 
 interface GitHubClientOptions {
   getToken(host: string, createIfNone?: boolean): Promise<string | undefined>;
   getWebCookie?(host: string): Promise<string | undefined>;
+  browserWebHtmlProvider?(url: string): Promise<string | undefined>;
   fetch?: FetchLike;
 }
 
 interface AuthRequestOptions {
   promptForAuth?: boolean;
+}
+
+interface WebSuggestionRequestOptions {
+  allowBrowserFallback?: boolean;
 }
 
 interface GraphQLPageInfo {
@@ -29,7 +34,7 @@ interface GraphQLPageInfo {
 
 interface GraphQLCommentNode {
   id: string;
-  databaseId?: number;
+  databaseId?: number | string;
   body?: string;
   diffHunk?: string | null;
   path?: string | null;
@@ -222,26 +227,73 @@ export class GitHubClient {
     }
   }
 
-  async getWebSuggestedDiffs(repository: RepositoryRef, prNumber: number): Promise<Map<string, SuggestedDiff[]>> {
+  async getWebSuggestedDiffs(
+    repository: RepositoryRef,
+    prNumber: number,
+    options: WebSuggestionRequestOptions = {},
+  ): Promise<WebSuggestedDiffResult> {
     if (repository.host.toLowerCase() !== 'github.com') {
-      return new Map();
+      return { suggestions: new Map(), provenance: 'externalBotUnavailable' };
     }
 
-    const cookie = sanitizeHeaderValue(await this.options.getWebCookie?.(repository.host));
-    if (cookie === undefined) {
-      return new Map();
+    const url = `https://github.com/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pull/${prNumber}/files`;
+    const publicHtml = await this.fetchGitHubWebHtml(url, undefined, false);
+    if (publicHtml !== undefined) {
+      const publicSuggestions = extractAutomatedSuggestedDiffsFromHtml(publicHtml, 'githubWebAutomatedDiff');
+      if (publicSuggestions.size > 0) {
+        return { suggestions: publicSuggestions, provenance: 'githubWebAutomatedDiff' };
+      }
     }
 
-    const response = await this.fetch(
-      `https://github.com/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pull/${prNumber}/files`,
-      { headers: { Cookie: cookie } },
-    );
+    const safeCookie = sanitizeHeaderValue(await this.options.getWebCookie?.(repository.host));
+    let privateFetchError: unknown;
+    if (safeCookie !== undefined) {
+      try {
+        const privateHtml = await this.fetchGitHubWebHtml(url, { Cookie: safeCookie }, true);
+        if (privateHtml !== undefined) {
+          const privateSuggestions = extractAutomatedSuggestedDiffsFromHtml(privateHtml, 'githubWebAutomatedDiff');
+          if (privateSuggestions.size > 0) {
+            return { suggestions: privateSuggestions, provenance: 'githubWebAutomatedDiff' };
+          }
+        }
+      } catch (error) {
+        privateFetchError = error;
+      }
+    }
+
+    if (options.allowBrowserFallback === true && this.options.browserWebHtmlProvider !== undefined) {
+      const browserHtml = await this.options.browserWebHtmlProvider(url);
+      if (browserHtml !== undefined) {
+        const browserSuggestions = extractAutomatedSuggestedDiffsFromHtml(browserHtml, 'browserDomAutomatedDiff');
+        if (browserSuggestions.size > 0) {
+          return { suggestions: browserSuggestions, provenance: 'browserDomAutomatedDiff' };
+        }
+      }
+    }
+
+    if (privateFetchError !== undefined) {
+      throw privateFetchError;
+    }
+
+    return { suggestions: new Map(), provenance: 'externalBotUnavailable' };
+  }
+
+  private async fetchGitHubWebHtml(
+    url: string,
+    headers: Record<string, string> | undefined,
+    throwOnFailure: boolean,
+  ): Promise<string | undefined> {
+    const response = await this.fetch(url, headers === undefined ? undefined : { headers });
     const html = await response.text();
     if (!response.ok) {
-      throw new HttpError('Fetch GitHub web PR page failed.', response.status, html);
+      if (throwOnFailure) {
+        throw new HttpError('Fetch GitHub web PR page failed.', response.status, html);
+      }
+
+      return undefined;
     }
 
-    return extractAutomatedSuggestedDiffsFromHtml(html);
+    return html;
   }
 
   private async fetchGraphQLReviewThreads(repository: RepositoryRef, prNumber: number, token: string): Promise<ReviewThread[]> {
@@ -555,7 +607,8 @@ function mergeRestComments(threads: ReviewThread[], restComments: readonly RestR
 
   for (const thread of threads) {
     for (const comment of thread.comments) {
-      const rest = comment.databaseId === undefined ? undefined : byDatabaseId.get(comment.databaseId) ?? byNodeId.get(comment.id ?? '');
+      const restByDatabaseId = typeof comment.databaseId === 'number' ? byDatabaseId.get(comment.databaseId) : undefined;
+      const rest = restByDatabaseId ?? byNodeId.get(comment.id ?? '');
       if (rest === undefined) {
         continue;
       }

--- a/Extensions/WallstopPrComments/src/markdownSuggestions.ts
+++ b/Extensions/WallstopPrComments/src/markdownSuggestions.ts
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it';
 
-import type { SuggestedChange } from './types';
+import type { EmbeddedLocation, SuggestedChange } from './types';
 
 interface MarkdownToken {
   type: string;
@@ -18,7 +18,7 @@ const markdown = new MarkdownIt({
 
 export function extractSuggestionBlocks(
   text: string | undefined,
-  metadata: Omit<SuggestedChange, 'kind' | 'value'> = {},
+  metadata: Omit<SuggestedChange, 'kind' | 'value' | 'source' | 'confidence'> = {},
 ): SuggestedChange[] {
   if (text === undefined || text.trim() === '') {
     return [];
@@ -29,8 +29,10 @@ export function extractSuggestionBlocks(
     .map((token) => ({
       kind: 'suggestion',
       value: token.content.replace(/\n+$/u, ''),
+      source: 'apiMarkdownSuggestion',
+      confidence: 'high',
       ...metadata,
-    }));
+    } satisfies SuggestedChange));
 }
 
 export function cleanCommentText(text: string | undefined): string {
@@ -48,8 +50,18 @@ export function cleanCommentText(text: string | undefined): string {
     (token) => token.type === 'fence',
     (token) => token.content.replace(/\n+$/u, '').split('\n'),
   );
+  const withoutCursorButtons = removeHtmlBlocksContainingText(
+    withoutFenceMarkers,
+    'div',
+    /cursor\.com\/(?:open|agents)|fix-in-(?:cursor|web)/iu,
+  );
+  const withoutCursorFooter = removeHtmlBlocksContainingText(
+    withoutCursorButtons,
+    'sup',
+    /Reviewed by\s+\[?Cursor Bugbot|cursor\.com\/bugbot/iu,
+  );
 
-  return withoutFenceMarkers
+  return withoutCursorFooter
     .replace(/<!--[\s\S]*?-->/gu, ' ')
     .replace(/<details\b[^>]*>\s*<summary\b[^>]*>\s*Additional Locations[\s\S]*?<\/details>/giu, ' ')
     .replace(/!\[[^\]]*\]\([^)]*\)/gu, ' ')
@@ -58,6 +70,43 @@ export function cleanCommentText(text: string | undefined): string {
     .replace(/&nbsp;/gu, ' ')
     .replace(/\s+/gu, ' ')
     .trim();
+}
+
+export function extractEmbeddedCommentLocations(text: string | undefined): EmbeddedLocation[] {
+  if (text === undefined || text.trim() === '') {
+    return [];
+  }
+
+  const locations: EmbeddedLocation[] = [];
+  const seen = new Set<string>();
+  const blockRegex = /<!--\s*LOCATIONS\s+START\s+(?<payload>[\s\S]*?)\s+LOCATIONS\s+END\s*-->/giu;
+  for (const block of text.matchAll(blockRegex)) {
+    const payload = block.groups?.payload ?? '';
+    const locationRegex = /(?<target>\S+?)#L(?<start>\d+)(?:-L?(?<end>\d+))?/gu;
+    for (const location of payload.matchAll(locationRegex)) {
+      const path = normalizeEmbeddedLocationPath(location.groups?.target ?? '');
+      const start = Number.parseInt(location.groups?.start ?? '', 10);
+      if (path === undefined || !Number.isInteger(start) || start < 1) {
+        continue;
+      }
+
+      const parsedEnd = Number.parseInt(location.groups?.end ?? '', 10);
+      let end = Number.isInteger(parsedEnd) && parsedEnd >= 1 ? parsedEnd : start;
+      if (end < start) {
+        end = start;
+      }
+
+      const key = `${path.toLowerCase()}|${start}|${end}`;
+      if (seen.has(key)) {
+        continue;
+      }
+
+      locations.push({ path, lineStart: start, lineEnd: end });
+      seen.add(key);
+    }
+  }
+
+  return locations;
 }
 
 export function isLikelyWebOnlySuggestedChangeset(input: {
@@ -72,7 +121,7 @@ export function isLikelyWebOnlySuggestedChangeset(input: {
   const body = input.body ?? '';
   const author = input.authorLogin ?? '';
   const botAuthor = /\b(copilot|cursor|bugbot)\b|copilot-pull-request-reviewer/iu.test(author);
-  const bodyLooksLikeWebSuggestion = /suggested changeset|web-only suggested|suggested change.*GitHub web UI|Copilot suggested/iu.test(body);
+  const bodyLooksLikeWebSuggestion = /suggested changeset|web-only suggested|suggested change.*GitHub web UI|Copilot suggested|BUGBOT_BUG_ID|cursor\.com\/(?:open|agents)/iu.test(body);
   return bodyLooksLikeWebSuggestion && (botAuthor || /suggested changeset/iu.test(body));
 }
 
@@ -80,8 +129,79 @@ export function webOnlyUnavailableReason(): string {
   return 'GitHub web-only suggested changeset could not be extracted from the public API.';
 }
 
+export function externalBotUnavailableReason(): string {
+  return 'External bot suggested fix was not exposed by the GitHub API.';
+}
+
+export function suggestedDiffUnavailableReason(input: {
+  authorLogin?: string;
+  body?: string;
+  suggestionCount: number;
+}): string | undefined {
+  if (input.suggestionCount > 0) {
+    return undefined;
+  }
+
+  const body = input.body ?? '';
+  const author = input.authorLogin ?? '';
+  if (/\b(cursor|bugbot)\b/iu.test(author) || /BUGBOT_BUG_ID|cursor\.com\/(?:open|agents)/iu.test(body)) {
+    return externalBotUnavailableReason();
+  }
+
+  if (/^copilot-pull-request-reviewer(?:\[bot\])?$/iu.test(author) || /Copilot suggested|suggested changeset/iu.test(body)) {
+    return webOnlyUnavailableReason();
+  }
+
+  return undefined;
+}
+
 function normalizeLineEndings(text: string): string {
   return text.replace(/\r\n/gu, '\n').replace(/\r/gu, '\n');
+}
+
+function removeHtmlBlocksContainingText(text: string, elementName: string, marker: RegExp): string {
+  if (text.trim() === '') {
+    return text;
+  }
+
+  const escapedName = escapeRegExp(elementName);
+  const blockRegex = new RegExp(`<${escapedName}\\b[^>]*>[\\s\\S]*?<\\/${escapedName}>`, 'giu');
+  return text.replace(blockRegex, (block) => (marker.test(block) ? ' ' : block));
+}
+
+function normalizeEmbeddedLocationPath(target: string): string | undefined {
+  let candidate = target.trim();
+  if (candidate === '') {
+    return undefined;
+  }
+
+  if (/^https?:\/\//iu.test(candidate)) {
+    try {
+      const url = new URL(candidate);
+      const segments = url.pathname.split('/').filter((segment) => segment !== '');
+      const blobIndex = segments.findIndex((segment) => segment === 'blob');
+      if (blobIndex >= 0 && segments.length > blobIndex + 2) {
+        candidate = segments.slice(blobIndex + 2).join('/');
+      } else {
+        candidate = url.pathname;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  try {
+    candidate = decodeURIComponent(candidate);
+  } catch {
+    // Keep the original text when percent-decoding is malformed.
+  }
+
+  const normalized = candidate.replace(/\\/gu, '/').trim().replace(/^\/+/u, '');
+  return normalized === '' ? undefined : normalized;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }
 
 function firstInfoWord(info: string): string {

--- a/Extensions/WallstopPrComments/src/markdownSuggestions.ts
+++ b/Extensions/WallstopPrComments/src/markdownSuggestions.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 
-import type { EmbeddedLocation, SuggestedChange } from './types';
+import { isCopilotPullRequestReviewerAuthor, isCursorBugbotAuthor } from './botAuthors';
+import type { EmbeddedLocation, SuggestedChange, UnavailableSuggestionSource } from './types';
 
 interface MarkdownToken {
   type: string;
@@ -120,9 +121,7 @@ export function isLikelyWebOnlySuggestedChangeset(input: {
 
   const body = input.body ?? '';
   const author = input.authorLogin ?? '';
-  const botAuthor = /\b(copilot|cursor|bugbot)\b|copilot-pull-request-reviewer/iu.test(author);
-  const bodyLooksLikeWebSuggestion = /suggested changeset|web-only suggested|suggested change.*GitHub web UI|Copilot suggested|BUGBOT_BUG_ID|cursor\.com\/(?:open|agents)/iu.test(body);
-  return bodyLooksLikeWebSuggestion && (botAuthor || /suggested changeset/iu.test(body));
+  return isCopilotPullRequestReviewerAuthor(author) && hasCopilotWebOnlySuggestionMarker(body);
 }
 
 export function webOnlyUnavailableReason(): string {
@@ -133,26 +132,48 @@ export function externalBotUnavailableReason(): string {
   return 'External bot suggested fix was not exposed by the GitHub API.';
 }
 
-export function suggestedDiffUnavailableReason(input: {
+export interface SuggestedDiffUnavailable {
+  reason: string;
+  source: UnavailableSuggestionSource;
+  confidence: 'unavailable';
+}
+
+export function suggestedDiffUnavailable(input: {
   authorLogin?: string;
   body?: string;
   suggestionCount: number;
-}): string | undefined {
+}): SuggestedDiffUnavailable | undefined {
   if (input.suggestionCount > 0) {
     return undefined;
   }
 
   const body = input.body ?? '';
   const author = input.authorLogin ?? '';
-  if (/\b(cursor|bugbot)\b/iu.test(author) || /BUGBOT_BUG_ID|cursor\.com\/(?:open|agents)/iu.test(body)) {
-    return externalBotUnavailableReason();
+  if (isCursorBugbotAuthor(author) && hasCursorBugbotExternalFixMarker(body)) {
+    return {
+      reason: externalBotUnavailableReason(),
+      source: 'externalBotUnavailable',
+      confidence: 'unavailable',
+    };
   }
 
-  if (/^copilot-pull-request-reviewer(?:\[bot\])?$/iu.test(author) || /Copilot suggested|suggested changeset/iu.test(body)) {
-    return webOnlyUnavailableReason();
+  if (isCopilotPullRequestReviewerAuthor(author) && hasCopilotWebOnlySuggestionMarker(body)) {
+    return {
+      reason: webOnlyUnavailableReason(),
+      source: 'webOnlyUnavailable',
+      confidence: 'unavailable',
+    };
   }
 
   return undefined;
+}
+
+function hasCursorBugbotExternalFixMarker(body: string): boolean {
+  return /BUGBOT_BUG_ID|cursor\.com\/(?:open|agents)/iu.test(body);
+}
+
+function hasCopilotWebOnlySuggestionMarker(body: string): boolean {
+  return /Copilot suggested|suggested changeset|web-only suggested|suggested change.*GitHub web UI/iu.test(body);
 }
 
 function normalizeLineEndings(text: string): string {

--- a/Extensions/WallstopPrComments/src/records.ts
+++ b/Extensions/WallstopPrComments/src/records.ts
@@ -1,22 +1,33 @@
 import {
   cleanCommentText,
+  extractEmbeddedCommentLocations,
   extractSuggestionBlocks,
-  isLikelyWebOnlySuggestedChangeset,
-  webOnlyUnavailableReason,
+  suggestedDiffUnavailableReason,
 } from './markdownSuggestions';
-import type { RenderableComment, ReviewComment, ReviewThread, ReviewThreadRecord } from './types';
+import type { EmbeddedLocation, RenderableComment, ReviewComment, ReviewThread, ReviewThreadRecord } from './types';
 
 export function reviewThreadToRecord(thread: ReviewThread): ReviewThreadRecord | undefined {
-  const range = resolveLineRange(thread);
+  const githubPath = normalizePath(thread.path);
+  const githubRange = resolveLineRange(thread);
+  const topComment = thread.comments[0];
+  const embeddedLocations = isTrustedEmbeddedLocationAuthor(topComment?.authorLogin)
+    ? extractEmbeddedCommentLocations(topComment?.body)
+    : [];
+  const outputLocation = resolveOutputLocation(githubPath, githubRange, embeddedLocations);
   const comments = thread.comments.map(toRenderableComment).filter((comment) => hasRenderableCommentContent(comment));
   if (comments.length === 0) {
     return undefined;
   }
 
   return {
-    path: normalizePath(thread.path),
-    lineStart: range.start,
-    lineEnd: range.end,
+    path: outputLocation.path,
+    lineStart: outputLocation.start,
+    lineEnd: outputLocation.end,
+    locationSource: outputLocation.source,
+    githubPath,
+    githubLineStart: githubRange.start,
+    githubLineEnd: githubRange.end,
+    embeddedLocations,
     comments,
   };
 }
@@ -66,24 +77,85 @@ function toRenderableComment(comment: ReviewComment, commentIndex: number): Rend
   });
   const body = cleanCommentText(comment.body);
   const suggestedDiffs = [...(comment.suggestedDiffs ?? [])];
-  const unavailableReason =
-    suggestedDiffs.length === 0 &&
-    isLikelyWebOnlySuggestedChangeset({
-      authorLogin: comment.authorLogin,
-      body: comment.body,
-      suggestionCount: suggestedChanges.length,
-    })
-      ? webOnlyUnavailableReason()
-      : undefined;
+  const unavailableReason = suggestedDiffs.length === 0
+    ? suggestedDiffUnavailableReason({
+        authorLogin: comment.authorLogin,
+        body: comment.body,
+        suggestionCount: suggestedChanges.length,
+      })
+    : undefined;
 
   return {
     databaseId: comment.databaseId,
+    url: comment.url,
     body,
     suggestedChanges,
     suggestedDiffs,
     unavailableReason,
+    unavailableSource: unavailableReason === undefined ? undefined : 'externalBotUnavailable',
+    unavailableConfidence: unavailableReason === undefined ? undefined : 'unavailable',
   };
 }
+
+function resolveOutputLocation(
+  githubPath: string,
+  githubRange: { start?: number; end?: number },
+  embeddedLocations: readonly EmbeddedLocation[],
+): { path: string; start?: number; end?: number; source: 'github' | 'embedded' } {
+  const preferred = selectEmbeddedLocation(githubPath, embeddedLocations);
+  if (preferred !== undefined) {
+    return {
+      path: preferred.path,
+      start: preferred.lineStart,
+      end: preferred.lineEnd,
+      source: 'embedded',
+    };
+  }
+
+  return {
+    path: githubPath,
+    start: githubRange.start,
+    end: githubRange.end,
+    source: 'github',
+  };
+}
+
+function selectEmbeddedLocation(
+  githubPath: string,
+  embeddedLocations: readonly EmbeddedLocation[],
+): EmbeddedLocation | undefined {
+  if (embeddedLocations.length === 0) {
+    return undefined;
+  }
+
+  if (githubPath !== '<conversation>') {
+    const exact = embeddedLocations.find((location) => location.path === githubPath);
+    if (exact !== undefined) {
+      return exact;
+    }
+
+    const insensitive = embeddedLocations.find((location) => location.path.toLowerCase() === githubPath.toLowerCase());
+    if (insensitive !== undefined) {
+      return insensitive;
+    }
+
+    return undefined;
+  }
+
+  return embeddedLocations[0];
+}
+
+function isTrustedEmbeddedLocationAuthor(authorLogin: string | undefined): boolean {
+  if (authorLogin === undefined) {
+    return false;
+  }
+
+  const normalized = authorLogin.toLowerCase();
+  return normalized === 'cursor[bot]' ||
+    normalized === 'bugbot[bot]' ||
+    normalized === 'cursor-bugbot[bot]';
+}
+
 function resolveLineRange(thread: ReviewThread): { start?: number; end?: number } {
   const currentStart = thread.startLine;
   const currentEnd = thread.line;

--- a/Extensions/WallstopPrComments/src/records.ts
+++ b/Extensions/WallstopPrComments/src/records.ts
@@ -2,8 +2,9 @@ import {
   cleanCommentText,
   extractEmbeddedCommentLocations,
   extractSuggestionBlocks,
-  suggestedDiffUnavailableReason,
+  suggestedDiffUnavailable,
 } from './markdownSuggestions';
+import { isCursorBugbotAuthor } from './botAuthors';
 import type { EmbeddedLocation, RenderableComment, ReviewComment, ReviewThread, ReviewThreadRecord } from './types';
 
 export function reviewThreadToRecord(thread: ReviewThread): ReviewThreadRecord | undefined {
@@ -77,8 +78,8 @@ function toRenderableComment(comment: ReviewComment, commentIndex: number): Rend
   });
   const body = cleanCommentText(comment.body);
   const suggestedDiffs = [...(comment.suggestedDiffs ?? [])];
-  const unavailableReason = suggestedDiffs.length === 0
-    ? suggestedDiffUnavailableReason({
+  const unavailable = suggestedDiffs.length === 0
+    ? suggestedDiffUnavailable({
         authorLogin: comment.authorLogin,
         body: comment.body,
         suggestionCount: suggestedChanges.length,
@@ -91,9 +92,9 @@ function toRenderableComment(comment: ReviewComment, commentIndex: number): Rend
     body,
     suggestedChanges,
     suggestedDiffs,
-    unavailableReason,
-    unavailableSource: unavailableReason === undefined ? undefined : 'externalBotUnavailable',
-    unavailableConfidence: unavailableReason === undefined ? undefined : 'unavailable',
+    unavailableReason: unavailable?.reason,
+    unavailableSource: unavailable?.source,
+    unavailableConfidence: unavailable?.confidence,
   };
 }
 
@@ -146,14 +147,7 @@ function selectEmbeddedLocation(
 }
 
 function isTrustedEmbeddedLocationAuthor(authorLogin: string | undefined): boolean {
-  if (authorLogin === undefined) {
-    return false;
-  }
-
-  const normalized = authorLogin.toLowerCase();
-  return normalized === 'cursor[bot]' ||
-    normalized === 'bugbot[bot]' ||
-    normalized === 'cursor-bugbot[bot]';
+  return isCursorBugbotAuthor(authorLogin);
 }
 
 function resolveLineRange(thread: ReviewThread): { start?: number; end?: number } {

--- a/Extensions/WallstopPrComments/src/renderer.ts
+++ b/Extensions/WallstopPrComments/src/renderer.ts
@@ -30,7 +30,7 @@ export function formatReviewThreadRecords(records: readonly ReviewThreadRecord[]
       }
 
       for (const diff of comment.suggestedDiffs) {
-        addSuggestedChange(lines, diff.value);
+        addSuggestedChange(lines, diff.value, suggestedDiffLabel(record.path, diff.path));
       }
 
       if (!hasPublicText(comment) && comment.unavailableReason !== undefined) {
@@ -44,11 +44,26 @@ export function formatReviewThreadRecords(records: readonly ReviewThreadRecord[]
   return lines.join('\n');
 }
 
-function addSuggestedChange(lines: string[], value: string): void {
-  lines.push('Suggested change:');
+function addSuggestedChange(lines: string[], value: string, label = 'Suggested change:'): void {
+  lines.push(label);
   lines.push(...value.split('\n'));
 }
 
 function hasPublicText(comment: RenderableComment): boolean {
   return comment.body !== '' || comment.suggestedChanges.length > 0 || comment.suggestedDiffs.length > 0;
+}
+
+function suggestedDiffLabel(recordPath: string, diffPath: string | undefined): string {
+  if (diffPath === undefined) {
+    return 'Suggested change:';
+  }
+
+  const normalizedDiffPath = normalizePath(diffPath);
+  return normalizedDiffPath === normalizePath(recordPath)
+    ? 'Suggested change:'
+    : `Suggested change (${normalizedDiffPath}):`;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/gu, '/').replace(/[\r\n]+/gu, ' ').trim();
 }

--- a/Extensions/WallstopPrComments/src/types.ts
+++ b/Extensions/WallstopPrComments/src/types.ts
@@ -1,4 +1,10 @@
 export type ReviewScope = 'unresolved' | 'all' | 'resolved';
+export type SuggestionSource =
+  | 'apiMarkdownSuggestion'
+  | 'githubWebAutomatedDiff'
+  | 'browserDomAutomatedDiff'
+  | 'externalBotUnavailable';
+export type SuggestionConfidence = 'high' | 'medium' | 'unavailable';
 
 export interface RepositoryRef {
   host: string;
@@ -21,6 +27,8 @@ export interface PullRequestSummary {
 export interface SuggestedChange {
   kind: 'suggestion';
   value: string;
+  source: 'apiMarkdownSuggestion';
+  confidence: 'high';
   authorLogin?: string;
   commentIndex?: number;
   url?: string;
@@ -29,13 +37,15 @@ export interface SuggestedChange {
 export interface SuggestedDiff {
   kind: 'changedLines';
   value: string;
+  source: 'githubWebAutomatedDiff' | 'browserDomAutomatedDiff';
+  confidence: 'medium';
   path?: string;
 }
 
 export interface ReviewComment {
   id?: string;
   nodeId?: string;
-  databaseId?: number;
+  databaseId?: number | string;
   body: string;
   authorLogin?: string;
   url?: string;
@@ -61,21 +71,40 @@ export interface ReviewThread {
 }
 
 export interface RenderableComment {
-  databaseId?: number;
+  databaseId?: number | string;
+  url?: string;
   body: string;
   suggestedChanges: SuggestedChange[];
   suggestedDiffs: SuggestedDiff[];
   unavailableReason?: string;
+  unavailableSource?: 'externalBotUnavailable';
+  unavailableConfidence?: 'unavailable';
+}
+
+export interface EmbeddedLocation {
+  path: string;
+  lineStart: number;
+  lineEnd: number;
 }
 
 export interface ReviewThreadRecord {
   path: string;
   lineStart?: number;
   lineEnd?: number;
+  locationSource?: 'github' | 'embedded';
+  githubPath?: string;
+  githubLineStart?: number;
+  githubLineEnd?: number;
+  embeddedLocations?: EmbeddedLocation[];
   comments: RenderableComment[];
 }
 
 export interface ReviewThreadResult {
   threads: ReviewThread[];
   warnings: string[];
+}
+
+export interface WebSuggestedDiffResult {
+  suggestions: Map<string, SuggestedDiff[]>;
+  provenance: SuggestionSource;
 }

--- a/Extensions/WallstopPrComments/src/types.ts
+++ b/Extensions/WallstopPrComments/src/types.ts
@@ -1,9 +1,11 @@
 export type ReviewScope = 'unresolved' | 'all' | 'resolved';
+export type AutomatedSuggestionSource = 'githubWebAutomatedDiff' | 'browserDomAutomatedDiff';
+export type UnavailableSuggestionSource = 'externalBotUnavailable' | 'webOnlyUnavailable';
+export type WebSuggestedDiffProvenance = AutomatedSuggestionSource | 'webOnlyUnavailable';
 export type SuggestionSource =
   | 'apiMarkdownSuggestion'
-  | 'githubWebAutomatedDiff'
-  | 'browserDomAutomatedDiff'
-  | 'externalBotUnavailable';
+  | AutomatedSuggestionSource
+  | UnavailableSuggestionSource;
 export type SuggestionConfidence = 'high' | 'medium' | 'unavailable';
 
 export interface RepositoryRef {
@@ -37,7 +39,7 @@ export interface SuggestedChange {
 export interface SuggestedDiff {
   kind: 'changedLines';
   value: string;
-  source: 'githubWebAutomatedDiff' | 'browserDomAutomatedDiff';
+  source: AutomatedSuggestionSource;
   confidence: 'medium';
   path?: string;
 }
@@ -77,7 +79,7 @@ export interface RenderableComment {
   suggestedChanges: SuggestedChange[];
   suggestedDiffs: SuggestedDiff[];
   unavailableReason?: string;
-  unavailableSource?: 'externalBotUnavailable';
+  unavailableSource?: UnavailableSuggestionSource;
   unavailableConfidence?: 'unavailable';
 }
 
@@ -106,5 +108,5 @@ export interface ReviewThreadResult {
 
 export interface WebSuggestedDiffResult {
   suggestions: Map<string, SuggestedDiff[]>;
-  provenance: SuggestionSource;
+  provenance: WebSuggestedDiffProvenance;
 }

--- a/Extensions/WallstopPrComments/src/webSuggestions.ts
+++ b/Extensions/WallstopPrComments/src/webSuggestions.ts
@@ -1,10 +1,8 @@
-import type { RenderableComment, ReviewThreadRecord, SuggestedDiff } from './types';
-
-type AutomatedDiffSource = 'githubWebAutomatedDiff' | 'browserDomAutomatedDiff';
+import type { AutomatedSuggestionSource, RenderableComment, ReviewThreadRecord, SuggestedDiff } from './types';
 
 export function extractAutomatedSuggestedDiffsFromHtml(
   html: string,
-  source: AutomatedDiffSource = 'githubWebAutomatedDiff',
+  source: AutomatedSuggestionSource = 'githubWebAutomatedDiff',
 ): Map<string, SuggestedDiff[]> {
   const suggestionsByCommentId = new Map<string, SuggestedDiff[]>();
   for (const payload of extractJsonScriptPayloads(html)) {
@@ -28,14 +26,15 @@ export function attachWebSuggestedDiffs(
         continue;
       }
 
-      const existing = new Set(comment.suggestedDiffs.map((diff) => diff.value));
+      const existing = new Set(comment.suggestedDiffs.map(suggestedDiffIdentity));
       for (const diff of diffs) {
-        if (existing.has(diff.value)) {
+        const identity = suggestedDiffIdentity(diff);
+        if (existing.has(identity)) {
           continue;
         }
 
         comment.suggestedDiffs.push(diff);
-        existing.add(diff.value);
+        existing.add(identity);
         attachedCount++;
       }
 
@@ -96,7 +95,7 @@ function decodeHtmlEntities(value: string): string {
 function collectAutomatedDiffs(
   value: unknown,
   output: Map<string, SuggestedDiff[]>,
-  source: AutomatedDiffSource,
+  source: AutomatedSuggestionSource,
   depth = 0,
   keyHint?: string,
 ): void {
@@ -138,7 +137,7 @@ function collectAutomatedDiffs(
 function collectCandidate(
   value: Record<string, unknown>,
   output: Map<string, SuggestedDiff[]>,
-  source: AutomatedDiffSource,
+  source: AutomatedSuggestionSource,
 ): void {
   const comment = isRecord(value.comment) ? value.comment : value;
   const automatedComment = isRecord(comment.automatedComment) ? comment.automatedComment : undefined;
@@ -165,17 +164,30 @@ function collectCandidate(
   }
 
   const existing = output.get(commentKey) ?? [];
-  const seen = new Set(existing.map((diff) => diff.value));
+  const seen = new Set(existing.map(suggestedDiffIdentity));
   for (const diff of diffs) {
-    if (!seen.has(diff.value)) {
+    const identity = suggestedDiffIdentity(diff);
+    if (!seen.has(identity)) {
       existing.push(diff);
-      seen.add(diff.value);
+      seen.add(identity);
     }
   }
   output.set(commentKey, existing);
 }
 
-function toSuggestedDiff(entry: unknown, source: AutomatedDiffSource): SuggestedDiff | undefined {
+function suggestedDiffIdentity(diff: SuggestedDiff): string {
+  return JSON.stringify([
+    normalizeSuggestedDiffPath(diff.path),
+    diff.value,
+  ]);
+}
+
+function normalizeSuggestedDiffPath(path: string | undefined): string | undefined {
+  const normalized = path?.replace(/\\/gu, '/').trim();
+  return normalized === '' ? undefined : normalized;
+}
+
+function toSuggestedDiff(entry: unknown, source: AutomatedSuggestionSource): SuggestedDiff | undefined {
   if (!isRecord(entry)) {
     return undefined;
   }

--- a/Extensions/WallstopPrComments/src/webSuggestions.ts
+++ b/Extensions/WallstopPrComments/src/webSuggestions.ts
@@ -1,12 +1,15 @@
-import type { ReviewThreadRecord, SuggestedDiff } from './types';
+import type { RenderableComment, ReviewThreadRecord, SuggestedDiff } from './types';
 
-export function extractAutomatedSuggestedDiffsFromHtml(html: string): Map<string, SuggestedDiff[]> {
+type AutomatedDiffSource = 'githubWebAutomatedDiff' | 'browserDomAutomatedDiff';
+
+export function extractAutomatedSuggestedDiffsFromHtml(
+  html: string,
+  source: AutomatedDiffSource = 'githubWebAutomatedDiff',
+): Map<string, SuggestedDiff[]> {
   const suggestionsByCommentId = new Map<string, SuggestedDiff[]>();
   for (const payload of extractJsonScriptPayloads(html)) {
-    try {
-      collectAutomatedDiffs(JSON.parse(payload), suggestionsByCommentId);
-    } catch {
-      // GitHub embeds many scripts; ignore non-JSON or unrelated fragments.
+    for (const parsed of parseJsonCandidates(payload)) {
+      collectAutomatedDiffs(parsed, suggestionsByCommentId, source);
     }
   }
 
@@ -20,11 +23,7 @@ export function attachWebSuggestedDiffs(
   let attachedCount = 0;
   for (const record of records) {
     for (const comment of record.comments) {
-      if (comment.databaseId === undefined) {
-        continue;
-      }
-
-      const diffs = suggestionsByCommentId.get(String(comment.databaseId));
+      const diffs = firstMatchingDiffs(comment, suggestionsByCommentId);
       if (diffs === undefined || diffs.length === 0) {
         continue;
       }
@@ -42,6 +41,8 @@ export function attachWebSuggestedDiffs(
 
       if (comment.suggestedDiffs.length > 0) {
         comment.unavailableReason = undefined;
+        comment.unavailableSource = undefined;
+        comment.unavailableConfidence = undefined;
       }
     }
   }
@@ -62,6 +63,27 @@ function extractJsonScriptPayloads(html: string): string[] {
   return payloads;
 }
 
+function parseJsonCandidates(value: string): unknown[] {
+  const parsed: unknown[] = [];
+  const candidates = [value, decodeHtmlEntities(value)];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (trimmed === '' || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+
+    try {
+      parsed.push(JSON.parse(trimmed));
+    } catch {
+      // GitHub embeds many scripts; ignore non-JSON or unrelated fragments.
+    }
+  }
+
+  return parsed;
+}
+
 function decodeHtmlEntities(value: string): string {
   return value
     .replace(/&quot;/gu, '"')
@@ -71,10 +93,34 @@ function decodeHtmlEntities(value: string): string {
     .replace(/&gt;/gu, '>');
 }
 
-function collectAutomatedDiffs(value: unknown, output: Map<string, SuggestedDiff[]>): void {
+function collectAutomatedDiffs(
+  value: unknown,
+  output: Map<string, SuggestedDiff[]>,
+  source: AutomatedDiffSource,
+  depth = 0,
+  keyHint?: string,
+): void {
+  if (depth > 12) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    if (!isNestedJsonWrapperKey(keyHint)) {
+      return;
+    }
+    if (!value.includes('automatedComment') && !value.includes('diffEntries')) {
+      return;
+    }
+
+    for (const parsed of parseJsonCandidates(value)) {
+      collectAutomatedDiffs(parsed, output, source, depth + 1);
+    }
+    return;
+  }
+
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectAutomatedDiffs(item, output);
+      collectAutomatedDiffs(item, output, source, depth + 1, keyHint);
     }
     return;
   }
@@ -83,36 +129,42 @@ function collectAutomatedDiffs(value: unknown, output: Map<string, SuggestedDiff
     return;
   }
 
-  collectCandidate(value, output);
-  for (const child of Object.values(value)) {
-    collectAutomatedDiffs(child, output);
+  collectCandidate(value, output, source);
+  for (const [key, child] of Object.entries(value)) {
+    collectAutomatedDiffs(child, output, source, depth + 1, key);
   }
 }
 
-function collectCandidate(value: Record<string, unknown>, output: Map<string, SuggestedDiff[]>): void {
+function collectCandidate(
+  value: Record<string, unknown>,
+  output: Map<string, SuggestedDiff[]>,
+  source: AutomatedDiffSource,
+): void {
   const comment = isRecord(value.comment) ? value.comment : value;
   const automatedComment = isRecord(comment.automatedComment) ? comment.automatedComment : undefined;
-  const source = automatedComment ?? value;
-  const suggestion = isRecord(source.suggestion) ? source.suggestion : undefined;
+  if (automatedComment === undefined) {
+    return;
+  }
+
+  const suggestion = isRecord(automatedComment.suggestion) ? automatedComment.suggestion : undefined;
   const diffEntries = Array.isArray(suggestion?.diffEntries) ? suggestion.diffEntries : undefined;
   if (diffEntries === undefined) {
     return;
   }
 
-  const databaseId = readDatabaseId(comment) ?? readDatabaseId(source) ?? readDatabaseId(value);
-  if (databaseId === undefined) {
+  const commentKey = readCommentKey(comment) ?? readCommentKey(automatedComment) ?? readCommentKey(value);
+  if (commentKey === undefined) {
     return;
   }
 
   const diffs = diffEntries
-    .map(toSuggestedDiff)
+    .map((entry) => toSuggestedDiff(entry, source))
     .filter((diff): diff is SuggestedDiff => diff !== undefined);
   if (diffs.length === 0) {
     return;
   }
 
-  const key = String(databaseId);
-  const existing = output.get(key) ?? [];
+  const existing = output.get(commentKey) ?? [];
   const seen = new Set(existing.map((diff) => diff.value));
   for (const diff of diffs) {
     if (!seen.has(diff.value)) {
@@ -120,10 +172,10 @@ function collectCandidate(value: Record<string, unknown>, output: Map<string, Su
       seen.add(diff.value);
     }
   }
-  output.set(key, existing);
+  output.set(commentKey, existing);
 }
 
-function toSuggestedDiff(entry: unknown): SuggestedDiff | undefined {
+function toSuggestedDiff(entry: unknown, source: AutomatedDiffSource): SuggestedDiff | undefined {
   if (!isRecord(entry)) {
     return undefined;
   }
@@ -141,7 +193,10 @@ function toSuggestedDiff(entry: unknown): SuggestedDiff | undefined {
     }
 
     const text = typeof line.text === 'string' ? line.text : '';
-    changedLines.push(`${type === 'DELETION' ? '-' : '+'}${text}`);
+    const prefix = type === 'DELETION' ? '-' : '+';
+    for (const textLine of normalizeDiffLineText(text)) {
+      changedLines.push(`${prefix}${textLine}`);
+    }
   }
 
   if (changedLines.length === 0) {
@@ -151,13 +206,74 @@ function toSuggestedDiff(entry: unknown): SuggestedDiff | undefined {
   return {
     kind: 'changedLines',
     path: typeof entry.path === 'string' ? entry.path : undefined,
+    source,
+    confidence: 'medium',
     value: changedLines.join('\n'),
   };
 }
 
-function readDatabaseId(value: Record<string, unknown>): number | undefined {
+function firstMatchingDiffs(
+  comment: RenderableComment,
+  suggestionsByCommentId: ReadonlyMap<string, SuggestedDiff[]>,
+): SuggestedDiff[] | undefined {
+  for (const key of commentKeyCandidates(comment)) {
+    const diffs = suggestionsByCommentId.get(key);
+    if (diffs !== undefined) {
+      return diffs;
+    }
+  }
+
+  return undefined;
+}
+
+function commentKeyCandidates(comment: RenderableComment): string[] {
+  const candidates: string[] = [];
+  if (comment.databaseId !== undefined) {
+    const databaseId = String(comment.databaseId);
+    candidates.push(databaseId);
+    const discussionMatch = /^discussion_r(?<id>\d+)$/iu.exec(databaseId);
+    if (discussionMatch?.groups?.id !== undefined) {
+      candidates.push(discussionMatch.groups.id);
+    }
+  }
+
+  const urlId = readDiscussionIdFromUrl(comment.url);
+  if (urlId !== undefined) {
+    candidates.push(urlId);
+    candidates.push(`discussion_r${urlId}`);
+  }
+
+  return [...new Set(candidates)];
+}
+
+function readCommentKey(value: Record<string, unknown>): string | undefined {
   const databaseId = value.databaseId;
-  return typeof databaseId === 'number' ? databaseId : undefined;
+  if (typeof databaseId === 'number' || typeof databaseId === 'string') {
+    const text = String(databaseId).trim();
+    if (text !== '') {
+      return text;
+    }
+  }
+
+  const url = typeof value.url === 'string' ? value.url : typeof value.html_url === 'string' ? value.html_url : undefined;
+  return readDiscussionIdFromUrl(url);
+}
+
+function readDiscussionIdFromUrl(url: string | undefined): string | undefined {
+  if (url === undefined) {
+    return undefined;
+  }
+
+  const match = /(?:#discussion_r|discussion_r)(?<id>\d+)/iu.exec(url);
+  return match?.groups?.id;
+}
+
+function isNestedJsonWrapperKey(key: string | undefined): boolean {
+  return key !== undefined && /^(?:payload|data|json|embeddedData|embedded_data|initialPayload)$/iu.test(key);
+}
+
+function normalizeDiffLineText(text: string): string[] {
+  return text.replace(/\r\n/gu, '\n').replace(/\r/gu, '\n').split('\n');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/Extensions/WallstopPrComments/test/extension.test.ts
+++ b/Extensions/WallstopPrComments/test/extension.test.ts
@@ -73,6 +73,30 @@ test('browser web suggestions provider invokes configured VS Code command with P
   ]);
 });
 
+test('browser web suggestions provider accepts object html results', async () => {
+  const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({
+    command: 'example.browserHtml',
+    executeCommand: async () => ({ html: '<script type="application/json">{}</script>' }),
+  });
+
+  assert.equal(
+    await getBrowserWebSuggestionsHtml('https://github.com/org/repo/pull/1/files'),
+    '<script type="application/json">{}</script>',
+  );
+});
+
+test('browser web suggestions provider error documents every supported return shape', async () => {
+  const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({
+    command: 'example.browserHtml',
+    executeCommand: async () => ({ text: '<html></html>' }),
+  });
+
+  await assert.rejects(
+    () => getBrowserWebSuggestionsHtml('https://github.com/org/repo/pull/1/files'),
+    /must return an HTML string or \{ html: string \}/u,
+  );
+});
+
 test('browser web suggestions provider is disabled when no command is configured', async () => {
   let called = false;
   const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({

--- a/Extensions/WallstopPrComments/test/extension.test.ts
+++ b/Extensions/WallstopPrComments/test/extension.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import test from 'node:test';
+
+function loadExtensionWithVscodeStub(options: {
+  command: string | undefined;
+  workspaceCommand?: string;
+  executeCommand: (command: string, url: string) => Promise<unknown>;
+}): { getBrowserWebSuggestionsHtml: (url: string) => Promise<string | undefined> } {
+  const moduleLoader = Module as unknown as {
+    _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+  };
+  const originalLoad = moduleLoader._load;
+  moduleLoader._load = (request, parent, isMain) => {
+    if (request === 'vscode') {
+      return {
+        authentication: { getSession: async () => undefined },
+        commands: {
+          executeCommand: options.executeCommand,
+          registerCommand: () => ({ dispose: () => undefined }),
+        },
+        env: {
+          clipboard: { writeText: async () => undefined },
+          openExternal: async () => undefined,
+        },
+        ProgressLocation: { Notification: 1 },
+        Uri: { parse: (value: string) => ({ value }) },
+        window: {
+          registerTreeDataProvider: () => ({ dispose: () => undefined }),
+          showErrorMessage: async () => undefined,
+          showInformationMessage: async () => undefined,
+          showInputBox: async () => undefined,
+          showQuickPick: async () => undefined,
+          showWarningMessage: async () => undefined,
+          withProgress: async (_options: unknown, task: () => Promise<unknown>) => task(),
+        },
+        workspace: {
+          getConfiguration: () => ({
+            inspect: (key: string) => key === 'browserWebSuggestionsCommand'
+              ? { globalValue: options.command, workspaceValue: options.workspaceCommand }
+              : undefined,
+          }),
+        },
+      };
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[require.resolve('../src/extension')];
+    return require('../src/extension') as { getBrowserWebSuggestionsHtml: (url: string) => Promise<string | undefined> };
+  } finally {
+    moduleLoader._load = originalLoad;
+  }
+}
+
+test('browser web suggestions provider invokes configured VS Code command with PR files URL', async () => {
+  const calls: Array<{ command: string; url: string }> = [];
+  const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({
+    command: 'example.browserHtml',
+    executeCommand: async (command, url) => {
+      calls.push({ command, url });
+      return '<script type="application/json">{}</script>';
+    },
+  });
+
+  const html = await getBrowserWebSuggestionsHtml('https://github.com/org/repo/pull/1/files');
+
+  assert.equal(html, '<script type="application/json">{}</script>');
+  assert.deepEqual(calls, [
+    { command: 'example.browserHtml', url: 'https://github.com/org/repo/pull/1/files' },
+  ]);
+});
+
+test('browser web suggestions provider is disabled when no command is configured', async () => {
+  let called = false;
+  const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({
+    command: '   ',
+    executeCommand: async () => {
+      called = true;
+      return '';
+    },
+  });
+
+  assert.equal(await getBrowserWebSuggestionsHtml('https://github.com/org/repo/pull/1/files'), undefined);
+  assert.equal(called, false);
+});
+
+test('browser web suggestions provider ignores workspace-supplied command setting', async () => {
+  let called = false;
+  const { getBrowserWebSuggestionsHtml } = loadExtensionWithVscodeStub({
+    command: undefined,
+    workspaceCommand: 'workspace.suppliedCommand',
+    executeCommand: async () => {
+      called = true;
+      return '';
+    },
+  });
+
+  assert.equal(await getBrowserWebSuggestionsHtml('https://github.com/org/repo/pull/1/files'), undefined);
+  assert.equal(called, false);
+});

--- a/Extensions/WallstopPrComments/test/githubClient.test.ts
+++ b/Extensions/WallstopPrComments/test/githubClient.test.ts
@@ -532,3 +532,154 @@ test('keeps GraphQL results when REST cross-check fails', async () => {
   assert.equal(result.threads[0].comments[0].body, 'GraphQL body');
   assert.match(result.warnings[0], /REST review-comment cross-check failed/i);
 });
+
+test('fetches public GitHub web suggested diffs without a cookie first', async () => {
+  const calls: Array<{ url: string; headers: Record<string, string> | undefined }> = [];
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({
+      url: String(url),
+      headers: init?.headers as Record<string, string> | undefined,
+    });
+    return new Response([
+      '<script type="application/json" data-target="react-partial.embeddedData">',
+      '{"props":{"comment":{"databaseId":42,"automatedComment":{"suggestion":{"diffEntries":[{"path":"src/public.ts","diffLines":[{"type":"DELETION","text":"old();"},{"type":"ADDITION","text":"new();"}]}]}}}}}',
+      '</script>',
+    ].join(''));
+  };
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => undefined,
+    fetch,
+  });
+
+  const result = await client.getWebSuggestedDiffs({ host: 'github.com', owner: 'org', repo: 'repo' }, 10);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://github.com/org/repo/pull/10/files');
+  assert.deepEqual(calls[0].headers, undefined);
+  assert.equal(result.suggestions.get('42')?.[0].source, 'githubWebAutomatedDiff');
+  assert.equal(result.provenance, 'githubWebAutomatedDiff');
+});
+
+test('retries private GitHub web suggested diffs with an explicit sanitized cookie after public fetch has no diffs', async () => {
+  const calls: Array<Record<string, string> | undefined> = [];
+  const fetch: FetchLike = async (_url, init) => {
+    calls.push(init?.headers as Record<string, string> | undefined);
+    if (calls.length === 1) {
+      return new Response('<html>Sign in</html>', { status: 200 });
+    }
+
+    return new Response([
+      '<script type="application/json" data-target="react-partial.embeddedData">',
+      '{"props":{"comment":{"databaseId":42,"automatedComment":{"suggestion":{"diffEntries":[{"path":"src/private.ts","diffLines":[{"type":"DELETION","text":"old();"},{"type":"ADDITION","text":"new();"}]}]}}}}}',
+      '</script>',
+    ].join(''));
+  };
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => '  user_session=abc\r\nInjected: nope  ',
+    fetch,
+  });
+
+  const result = await client.getWebSuggestedDiffs({ host: 'github.com', owner: 'org', repo: 'repo' }, 10);
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0], undefined);
+  assert.deepEqual(calls[1], { Cookie: 'user_session=abcInjected: nope' });
+  assert.equal(result.suggestions.get('42')?.[0].path, 'src/private.ts');
+});
+
+test('uses opt-in browser-backed extractor after raw GitHub web HTML exposes no diffs', async () => {
+  const fetch: FetchLike = async () => new Response('<html>No embedded suggestions</html>');
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => undefined,
+    fetch,
+    browserWebHtmlProvider: async (url) => {
+      assert.equal(url, 'https://github.com/org/repo/pull/10/files');
+      return [
+        '<script type="application/json" data-target="react-partial.embeddedData">',
+        '{"props":{"comment":{"databaseId":42,"automatedComment":{"suggestion":{"diffEntries":[{"path":"src/browser.ts","diffLines":[{"type":"DELETION","text":"old();"},{"type":"ADDITION","text":"new();"}]}]}}}}}',
+        '</script>',
+      ].join('');
+    },
+  });
+
+  const result = await client.getWebSuggestedDiffs(
+    { host: 'github.com', owner: 'org', repo: 'repo' },
+    10,
+    { allowBrowserFallback: true },
+  );
+
+  assert.equal(result.provenance, 'browserDomAutomatedDiff');
+  assert.equal(result.suggestions.get('42')?.[0].source, 'browserDomAutomatedDiff');
+  assert.equal(result.suggestions.get('42')?.[0].path, 'src/browser.ts');
+});
+
+test('uses opt-in browser-backed extractor when an explicit web cookie fetch fails', async () => {
+  const fetch: FetchLike = async (_url, init) => {
+    if (init?.headers !== undefined) {
+      return new Response('bad cookie', { status: 401 });
+    }
+
+    return new Response('<html>No embedded suggestions</html>');
+  };
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => 'user_session=stale',
+    fetch,
+    browserWebHtmlProvider: async () => [
+      '<script type="application/json" data-target="react-partial.embeddedData">',
+      '{"props":{"comment":{"databaseId":42,"automatedComment":{"suggestion":{"diffEntries":[{"path":"src/browser.ts","diffLines":[{"type":"DELETION","text":"old();"},{"type":"ADDITION","text":"new();"}]}]}}}}}',
+      '</script>',
+    ].join(''),
+  });
+
+  const result = await client.getWebSuggestedDiffs(
+    { host: 'github.com', owner: 'org', repo: 'repo' },
+    10,
+    { allowBrowserFallback: true },
+  );
+
+  assert.equal(result.provenance, 'browserDomAutomatedDiff');
+  assert.equal(result.suggestions.get('42')?.[0].path, 'src/browser.ts');
+});
+
+test('reports explicit web cookie failures when browser fallback cannot provide suggestions', async () => {
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => 'user_session=stale',
+    fetch: async (_url, init) => init?.headers === undefined
+      ? new Response('<html>No embedded suggestions</html>')
+      : new Response('bad cookie', { status: 401 }),
+    browserWebHtmlProvider: async () => '<html>No embedded suggestions</html>',
+  });
+
+  await assert.rejects(
+    () => client.getWebSuggestedDiffs(
+      { host: 'github.com', owner: 'org', repo: 'repo' },
+      10,
+      { allowBrowserFallback: true },
+    ),
+    /Fetch GitHub web PR page failed/,
+  );
+});
+
+test('does not use browser-backed extractor unless explicitly enabled', async () => {
+  let browserCalled = false;
+  const client = new GitHubClient({
+    getToken: async () => 'api-token',
+    getWebCookie: async () => undefined,
+    fetch: async () => new Response('<html>No embedded suggestions</html>'),
+    browserWebHtmlProvider: async () => {
+      browserCalled = true;
+      return '';
+    },
+  });
+
+  const result = await client.getWebSuggestedDiffs({ host: 'github.com', owner: 'org', repo: 'repo' }, 10);
+
+  assert.equal(browserCalled, false);
+  assert.equal(result.suggestions.size, 0);
+  assert.equal(result.provenance, 'externalBotUnavailable');
+});

--- a/Extensions/WallstopPrComments/test/githubClient.test.ts
+++ b/Extensions/WallstopPrComments/test/githubClient.test.ts
@@ -681,5 +681,5 @@ test('does not use browser-backed extractor unless explicitly enabled', async ()
 
   assert.equal(browserCalled, false);
   assert.equal(result.suggestions.size, 0);
-  assert.equal(result.provenance, 'externalBotUnavailable');
+  assert.equal(result.provenance, 'webOnlyUnavailable');
 });

--- a/Extensions/WallstopPrComments/test/parser.test.ts
+++ b/Extensions/WallstopPrComments/test/parser.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   cleanCommentText,
+  extractEmbeddedCommentLocations,
   extractSuggestionBlocks,
   isLikelyWebOnlySuggestedChangeset,
 } from '../src/markdownSuggestions';
@@ -22,6 +23,8 @@ test('extracts a single suggestion fence verbatim', () => {
   assert.deepEqual(extractSuggestionBlocks(body).map((item) => item.value), [
     'if (enabled) {\n  run();\n}',
   ]);
+  assert.deepEqual(extractSuggestionBlocks(body).map((item) => item.source), ['apiMarkdownSuggestion']);
+  assert.deepEqual(extractSuggestionBlocks(body).map((item) => item.confidence), ['high']);
 });
 
 test('extracts multiple suggestion fences in document order', () => {
@@ -95,4 +98,249 @@ test('marks likely Copilot web-only suggested changesets as unavailable instead 
   const body = 'Copilot suggested changeset available in the GitHub web UI.';
 
   assert.equal(isLikelyWebOnlySuggestedChangeset({ authorLogin: 'copilot-pull-request-reviewer[bot]', body, suggestionCount: 0 }), true);
+});
+
+test('strips Cursor and Bugbot chrome while preserving prose', () => {
+  const body = [
+    '<!-- BUGBOT_BUG_ID: 9ba7cf02-5286-48f8-9b14-368e1013dd72 -->',
+    '<!-- LOCATIONS START scripts/test-llm-harness.ps1#L93-L96 LOCATIONS END -->',
+    '### BOM test never actually writes a BOM **Low Severity**',
+    '<details><summary>Additional Locations (1)</summary>',
+    '- [`scripts/test-llm-harness.ps1#L110-L118`](https://github.com/org/repo/blob/sha/scripts/test-llm-harness.ps1#L110-L118)',
+    '</details>',
+    '<div><a href="https://cursor.com/open?link=abc"><picture><img alt="Fix in Cursor" src="https://cursor.com/assets/fix-in-cursor-dark.png"></picture></a></div>',
+    '<sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc.</sup>',
+  ].join('\n');
+
+  const cleaned = cleanCommentText(body);
+
+  assert.match(cleaned, /BOM test never actually writes a BOM/);
+  assert.doesNotMatch(cleaned, /BUGBOT_BUG_ID|LOCATIONS|Additional Locations|Fix in Cursor|Reviewed by|cursor\.com|https?:\/\/|<details|<div|<sup|!\[/);
+});
+
+test('extracts Cursor and Bugbot embedded locations in order', () => {
+  const body = '<!-- LOCATIONS START https://github.com/org/repo/blob/abc123/Scripts/Some%20File.ps1#L10 scripts/other.ps1#L20-L22 scripts/other.ps1#L30-L25 LOCATIONS END -->';
+
+  assert.deepEqual(extractEmbeddedCommentLocations(body), [
+    { path: 'Scripts/Some File.ps1', lineStart: 10, lineEnd: 10 },
+    { path: 'scripts/other.ps1', lineStart: 20, lineEnd: 22 },
+    { path: 'scripts/other.ps1', lineStart: 30, lineEnd: 30 },
+  ]);
+});
+
+test('uses embedded Cursor Bugbot locations for rendered record location', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'scripts/test-llm-harness.ps1',
+    isResolved: false,
+    startLine: 96,
+    line: 96,
+    originalStartLine: 96,
+    originalLine: 96,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'cursor[bot]',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START scripts/test-llm-harness.ps1#L93-L96 scripts/test-llm-harness.ps1#L110-L118 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, 'scripts/test-llm-harness.ps1');
+  assert.equal(record.lineStart, 93);
+  assert.equal(record.lineEnd, 96);
+  assert.equal(record.locationSource, 'embedded');
+  assert.equal(record.githubPath, 'scripts/test-llm-harness.ps1');
+  assert.equal(record.githubLineStart, 96);
+  assert.equal(record.githubLineEnd, 96);
+  assert.deepEqual(record.embeddedLocations, [
+    { path: 'scripts/test-llm-harness.ps1', lineStart: 93, lineEnd: 96 },
+    { path: 'scripts/test-llm-harness.ps1', lineStart: 110, lineEnd: 118 },
+  ]);
+});
+
+test('ignores mismatched embedded locations for file-anchored GitHub review threads', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'src/real.ts',
+    isResolved: false,
+    startLine: 10,
+    line: 12,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'cursor[bot]',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START src/other.ts#L1-L2 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, 'src/real.ts');
+  assert.equal(record.lineStart, 10);
+  assert.equal(record.lineEnd, 12);
+  assert.equal(record.locationSource, 'github');
+  assert.deepEqual(record.embeddedLocations, [
+    { path: 'src/other.ts', lineStart: 1, lineEnd: 2 },
+  ]);
+});
+
+test('ignores same-path embedded line overrides from non-bot comments', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'src/real.ts',
+    isResolved: false,
+    startLine: 10,
+    line: 12,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'human-reviewer',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START src/real.ts#L1-L2 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, 'src/real.ts');
+  assert.equal(record.lineStart, 10);
+  assert.equal(record.lineEnd, 12);
+  assert.equal(record.locationSource, 'github');
+  assert.deepEqual(record.embeddedLocations, []);
+});
+
+test('ignores embedded locations from human usernames that merely contain bot names', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'src/real.ts',
+    isResolved: false,
+    startLine: 10,
+    line: 12,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'cursor-fan',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START src/real.ts#L1-L2 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, 'src/real.ts');
+  assert.equal(record.lineStart, 10);
+  assert.equal(record.lineEnd, 12);
+  assert.equal(record.locationSource, 'github');
+  assert.deepEqual(record.embeddedLocations, []);
+});
+
+test('accepts embedded locations from known Cursor and Bugbot bot identities', () => {
+  for (const authorLogin of ['cursor[bot]', 'cursor-bugbot[bot]', 'bugbot[bot]']) {
+    const record = reviewThreadToRecord({
+      id: `thread-${authorLogin}`,
+      path: 'src/real.ts',
+      isResolved: false,
+      startLine: 10,
+      line: 12,
+      comments: [
+        {
+          id: 'comment-1',
+          authorLogin,
+          body: [
+            'Finding text.',
+            '<!-- LOCATIONS START src/real.ts#L1-L2 LOCATIONS END -->',
+          ].join('\n'),
+        },
+      ],
+    });
+
+    assert.ok(record);
+    assert.equal(record.lineStart, 1);
+    assert.equal(record.lineEnd, 2);
+    assert.equal(record.locationSource, 'embedded');
+  }
+});
+
+test('uses first embedded location for conversation-level comments without GitHub file anchors', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: '<conversation>',
+    isResolved: false,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'cursor[bot]',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START src/from-conversation.ts#L7-L9 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, 'src/from-conversation.ts');
+  assert.equal(record.lineStart, 7);
+  assert.equal(record.lineEnd, 9);
+  assert.equal(record.locationSource, 'embedded');
+});
+
+test('ignores embedded paths in conversation-level comments from non-bot authors', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: '<conversation>',
+    isResolved: false,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'human-reviewer',
+        body: [
+          'Finding text.',
+          '<!-- LOCATIONS START src/spoofed.ts#L7-L9 LOCATIONS END -->',
+        ].join('\n'),
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.path, '<conversation>');
+  assert.equal(record.lineStart, undefined);
+  assert.equal(record.lineEnd, undefined);
+  assert.equal(record.locationSource, 'github');
+  assert.deepEqual(record.embeddedLocations, []);
+});
+
+test('marks Cursor and Bugbot external fixes unavailable without fabricating a diff', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'src/cursor.ts',
+    isResolved: false,
+    line: 12,
+    comments: [
+      {
+        id: 'comment-1',
+        authorLogin: 'cursor[bot]',
+        body: 'Suggested changeset is available through <a href="https://cursor.com/open?link=abc">Fix in Cursor</a>.',
+        diffHunk: '@@ -1 +1 @@\n-old\n+new',
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(record.comments[0].unavailableReason, 'External bot suggested fix was not exposed by the GitHub API.');
+  assert.equal(record.comments[0].unavailableSource, 'externalBotUnavailable');
+  assert.equal(record.comments[0].unavailableConfidence, 'unavailable');
+  assert.deepEqual(record.comments[0].suggestedDiffs, []);
 });

--- a/Extensions/WallstopPrComments/test/parser.test.ts
+++ b/Extensions/WallstopPrComments/test/parser.test.ts
@@ -98,6 +98,56 @@ test('marks likely Copilot web-only suggested changesets as unavailable instead 
   const body = 'Copilot suggested changeset available in the GitHub web UI.';
 
   assert.equal(isLikelyWebOnlySuggestedChangeset({ authorLogin: 'copilot-pull-request-reviewer[bot]', body, suggestionCount: 0 }), true);
+  assert.equal(isLikelyWebOnlySuggestedChangeset({ authorLogin: 'human-reviewer', body, suggestionCount: 0 }), false);
+});
+
+test('does not classify human usernames containing bot names as unavailable suggested diffs', () => {
+  for (const [authorLogin, body] of [
+    ['cursor-fan', 'This normal review comment has no markdown suggestion.'],
+    ['bugbot-fan', 'Suggested changeset is available through https://cursor.com/open?link=abc.'],
+    ['not-copilot-reviewer', 'Copilot suggested changeset available in the GitHub web UI.'],
+    ['human-reviewer', '<!-- BUGBOT_BUG_ID: copied-marker --> Finding text.'],
+  ]) {
+    const record = reviewThreadToRecord({
+      id: `thread-${authorLogin}`,
+      path: 'src/human.ts',
+      isResolved: false,
+      line: 12,
+      comments: [
+        {
+          id: 'comment-1',
+          authorLogin,
+          body,
+        },
+      ],
+    });
+
+    assert.ok(record);
+    assert.equal(record.comments[0].unavailableReason, undefined);
+    assert.equal(record.comments[0].unavailableSource, undefined);
+  }
+});
+
+test('does not mark trusted bot prose as unavailable without a generated suggestion marker', () => {
+  for (const authorLogin of ['cursor[bot]', 'cursor-bugbot[bot]', 'bugbot[bot]', 'copilot-pull-request-reviewer[bot]']) {
+    const record = reviewThreadToRecord({
+      id: `thread-${authorLogin}`,
+      path: 'src/bot-prose.ts',
+      isResolved: false,
+      line: 12,
+      comments: [
+        {
+          id: 'comment-1',
+          authorLogin,
+          body: 'This finding has prose but no generated suggested-fix marker.',
+        },
+      ],
+    });
+
+    assert.ok(record);
+    assert.equal(record.comments[0].unavailableReason, undefined);
+    assert.equal(record.comments[0].unavailableSource, undefined);
+  }
 });
 
 test('strips Cursor and Bugbot chrome while preserving prose', () => {

--- a/Extensions/WallstopPrComments/test/renderer.test.ts
+++ b/Extensions/WallstopPrComments/test/renderer.test.ts
@@ -192,6 +192,7 @@ test('keeps unavailable web-only suggestions as metadata without fake suggested-
     record.comments[0].unavailableReason,
     'GitHub web-only suggested changeset could not be extracted from the public API.',
   );
+  assert.equal(record.comments[0].unavailableSource, 'webOnlyUnavailable');
   assert.deepEqual(collectUnavailableSuggestionWarnings([record]), [
     'src/copilot.ts:5: GitHub web-only suggested changeset could not be extracted from the public API.',
   ]);

--- a/Extensions/WallstopPrComments/test/renderer.test.ts
+++ b/Extensions/WallstopPrComments/test/renderer.test.ts
@@ -114,6 +114,8 @@ test('renders public web suggested diffs as changed lines only', () => {
         suggestedDiffs: [
           {
             kind: 'changedLines',
+            source: 'githubWebAutomatedDiff',
+            confidence: 'medium',
             value: '-          document.getElementById(id),\n+          element.ownerDocument.getElementById(id),',
           },
         ],
@@ -126,6 +128,46 @@ test('renders public web suggested diffs as changed lines only', () => {
 
   assert.match(output, /Suggested change:\n-          document\.getElementById\(id\),\n\+          element\.ownerDocument\.getElementById\(id\),/);
   assert.doesNotMatch(output, /@@|not\.toBeNull|CONTEXT/);
+});
+
+test('renders mismatched web suggested diff paths in the suggestion label', () => {
+  const record = reviewThreadToRecord({
+    id: 'thread-1',
+    path: 'src/commented.ts',
+    isResolved: false,
+    line: 10,
+    comments: [
+      {
+        id: 'comment-1',
+        body: 'Copilot suggested changeset available in the GitHub web UI.',
+        authorLogin: 'copilot-pull-request-reviewer[bot]',
+        suggestedDiffs: [
+          {
+            kind: 'changedLines',
+            source: 'githubWebAutomatedDiff',
+            confidence: 'medium',
+            path: 'src/changed.ts',
+            value: '-old();\n+new();',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.ok(record);
+  assert.equal(
+    formatReviewThreadRecords([record]),
+    [
+      '---',
+      '(src/commented.ts) 10-10',
+      'Comment:',
+      'Copilot suggested changeset available in the GitHub web UI.',
+      'Suggested change (src/changed.ts):',
+      '-old();',
+      '+new();',
+      '---',
+    ].join('\n'),
+  );
 });
 
 test('keeps unavailable web-only suggestions as metadata without fake suggested-change text', () => {

--- a/Extensions/WallstopPrComments/test/webSuggestions.test.ts
+++ b/Extensions/WallstopPrComments/test/webSuggestions.test.ts
@@ -201,6 +201,50 @@ test('uses discussion URL as a fallback id and deduplicates repeated changed-lin
   assert.equal(suggestions.get('99')?.[0].value, '-old();\n+new();');
 });
 
+test('keeps identical changed-line bodies when automated diff entries target different paths', () => {
+  const html = [
+    '<script type="application/json">',
+    JSON.stringify({
+      props: {
+        comment: {
+          databaseId: 42,
+          automatedComment: {
+            suggestion: {
+              diffEntries: [
+                {
+                  path: 'src/one.ts',
+                  diffLines: [
+                    { type: 'DELETION', text: 'old();' },
+                    { type: 'ADDITION', text: 'new();' },
+                  ],
+                },
+                {
+                  path: 'src/two.ts',
+                  diffLines: [
+                    { type: 'DELETION', text: 'old();' },
+                    { type: 'ADDITION', text: 'new();' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.deepEqual(
+    suggestions.get('42')?.map((diff) => ({ path: diff.path, value: diff.value })),
+    [
+      { path: 'src/one.ts', value: '-old();\n+new();' },
+      { path: 'src/two.ts', value: '-old();\n+new();' },
+    ],
+  );
+});
+
 test('ignores malformed web JSON and context-only automated diff entries', () => {
   const html = [
     '<script type="application/json">{not json}</script>',
@@ -227,7 +271,7 @@ test('attaches web suggestions by URL fallback when database id is missing', () 
           suggestedChanges: [],
           suggestedDiffs: [],
           unavailableReason: 'GitHub web-only suggested changeset could not be extracted from the public API.',
-          unavailableSource: 'externalBotUnavailable',
+          unavailableSource: 'webOnlyUnavailable',
           unavailableConfidence: 'unavailable',
         },
       ],
@@ -252,4 +296,51 @@ test('attaches web suggestions by URL fallback when database id is missing', () 
   assert.equal(attached, 1);
   assert.equal(records[0].comments[0].unavailableReason, undefined);
   assert.equal(records[0].comments[0].suggestedDiffs[0].value, '-old();\n+new();');
+});
+
+test('attaches identical changed-line bodies when suggested diffs target different paths', () => {
+  const records: ReviewThreadRecord[] = [
+    {
+      path: 'src/commented.ts',
+      lineStart: 4,
+      lineEnd: 4,
+      comments: [
+        {
+          databaseId: 42,
+          body: 'Copilot suggested changeset available in the GitHub web UI.',
+          suggestedChanges: [],
+          suggestedDiffs: [],
+        },
+      ],
+    },
+  ];
+  const suggestions = new Map([
+    [
+      '42',
+      [
+        {
+          kind: 'changedLines' as const,
+          path: 'src/one.ts',
+          source: 'githubWebAutomatedDiff' as const,
+          confidence: 'medium' as const,
+          value: '-old();\n+new();',
+        },
+        {
+          kind: 'changedLines' as const,
+          path: 'src/two.ts',
+          source: 'githubWebAutomatedDiff' as const,
+          confidence: 'medium' as const,
+          value: '-old();\n+new();',
+        },
+      ],
+    ],
+  ]);
+
+  const attached = attachWebSuggestedDiffs(records, suggestions);
+
+  assert.equal(attached, 2);
+  assert.deepEqual(records[0].comments[0].suggestedDiffs.map((diff) => diff.path), [
+    'src/one.ts',
+    'src/two.ts',
+  ]);
 });

--- a/Extensions/WallstopPrComments/test/webSuggestions.test.ts
+++ b/Extensions/WallstopPrComments/test/webSuggestions.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractAutomatedSuggestedDiffsFromHtml } from '../src/webSuggestions';
+import { attachWebSuggestedDiffs, extractAutomatedSuggestedDiffsFromHtml } from '../src/webSuggestions';
+import type { ReviewThreadRecord } from '../src/types';
 
 test('extracts GitHub web automated suggestions without review context lines', () => {
   const html = [
@@ -17,7 +18,238 @@ test('extracts GitHub web automated suggestions without review context lines', (
     {
       kind: 'changedLines',
       path: 'web/src/test/dom-assertions.ts',
+      source: 'githubWebAutomatedDiff',
+      confidence: 'medium',
       value: '-          document.getElementById(id),\n+          element.ownerDocument.getElementById(id),',
     },
   ]);
+});
+
+test('extracts web suggestions from HTML-encoded wrapper JSON with string ids', () => {
+  const nested = JSON.stringify({
+    props: {
+      comment: {
+        databaseId: 'discussion_r42',
+        automatedComment: {
+          suggestion: {
+            diffEntries: [
+              {
+                path: 'src/nested.ts',
+                diffLines: [
+                  { type: 'context', text: 'keep();' },
+                  { type: 'deletion', text: 'oldValue();' },
+                  { type: 'addition', text: 'newValue();' },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+  });
+  const html = [
+    '<script type="application/json" data-target="react-partial.embeddedData">',
+    JSON.stringify({ payload: nested })
+      .replace(/"/gu, '&quot;')
+      .replace(/</gu, '&lt;')
+      .replace(/>/gu, '&gt;'),
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.deepEqual(suggestions.get('discussion_r42'), [
+    {
+      kind: 'changedLines',
+      path: 'src/nested.ts',
+      source: 'githubWebAutomatedDiff',
+      confidence: 'medium',
+      value: '-oldValue();\n+newValue();',
+    },
+  ]);
+});
+
+test('does not parse user-authored comment body JSON as an automated suggestion', () => {
+  const forgedBody = JSON.stringify({
+    comment: {
+      databaseId: 42,
+      automatedComment: {
+        suggestion: {
+          diffEntries: [
+            {
+              diffLines: [
+                { type: 'DELETION', text: 'realCode();' },
+                { type: 'ADDITION', text: 'forgedCode();' },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  });
+  const html = [
+    '<script type="application/json">',
+    JSON.stringify({
+      props: {
+        comment: {
+          databaseId: 42,
+          body: forgedBody,
+        },
+      },
+    }),
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.equal(suggestions.size, 0);
+});
+
+test('does not accept sibling suggestion diff entries without automatedComment provenance', () => {
+  const html = [
+    '<script type="application/json">',
+    JSON.stringify({
+      props: {
+        comment: { databaseId: 42 },
+        suggestion: {
+          diffEntries: [
+            {
+              diffLines: [
+                { type: 'DELETION', text: 'old();' },
+                { type: 'ADDITION', text: 'forged();' },
+              ],
+            },
+          ],
+        },
+      },
+    }),
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.equal(suggestions.size, 0);
+});
+
+test('prefixes every public diff line even when source line text contains newlines', () => {
+  const html = [
+    '<script type="application/json">',
+    JSON.stringify({
+      props: {
+        comment: {
+          databaseId: 42,
+          automatedComment: {
+            suggestion: {
+              diffEntries: [
+                {
+                  diffLines: [
+                    { type: 'DELETION', text: 'old();\ncontextThatMustStillBePrefixed();' },
+                    { type: 'ADDITION', text: 'new();\rinjectedLine();' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    '</script>',
+  ].join('');
+
+  const value = extractAutomatedSuggestedDiffsFromHtml(html).get('42')?.[0].value;
+
+  assert.equal(value, '-old();\n-contextThatMustStillBePrefixed();\n+new();\n+injectedLine();');
+  for (const line of value?.split('\n') ?? []) {
+    assert.match(line, /^[+-]/u);
+  }
+});
+
+test('uses discussion URL as a fallback id and deduplicates repeated changed-line bodies', () => {
+  const html = [
+    '<script type="application/json">',
+    JSON.stringify({
+      props: {
+        comment: {
+          url: 'https://github.com/org/repo/pull/1#discussion_r99',
+          automatedComment: {
+            suggestion: {
+              diffEntries: [
+                {
+                  diffLines: [
+                    { type: 'DELETION', text: 'old();' },
+                    { type: 'ADDITION', text: 'new();' },
+                  ],
+                },
+                {
+                  diffLines: [
+                    { type: 'DELETION', text: 'old();' },
+                    { type: 'ADDITION', text: 'new();' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.equal(suggestions.get('99')?.length, 1);
+  assert.equal(suggestions.get('99')?.[0].value, '-old();\n+new();');
+});
+
+test('ignores malformed web JSON and context-only automated diff entries', () => {
+  const html = [
+    '<script type="application/json">{not json}</script>',
+    '<script type="application/json">',
+    '{"props":{"comment":{"databaseId":123,"automatedComment":{"suggestion":{"diffEntries":[{"diffLines":[{"type":"CONTEXT","text":"context only"}]}]}}}}}',
+    '</script>',
+  ].join('');
+
+  const suggestions = extractAutomatedSuggestedDiffsFromHtml(html);
+
+  assert.equal(suggestions.size, 0);
+});
+
+test('attaches web suggestions by URL fallback when database id is missing', () => {
+  const records: ReviewThreadRecord[] = [
+    {
+      path: 'src/fallback.ts',
+      lineStart: 4,
+      lineEnd: 4,
+      comments: [
+        {
+          body: 'Copilot suggested changeset available in the GitHub web UI.',
+          url: 'https://github.com/org/repo/pull/1#discussion_r99',
+          suggestedChanges: [],
+          suggestedDiffs: [],
+          unavailableReason: 'GitHub web-only suggested changeset could not be extracted from the public API.',
+          unavailableSource: 'externalBotUnavailable',
+          unavailableConfidence: 'unavailable',
+        },
+      ],
+    },
+  ];
+  const suggestions = new Map([
+    [
+      '99',
+      [
+        {
+          kind: 'changedLines' as const,
+          source: 'githubWebAutomatedDiff' as const,
+          confidence: 'medium' as const,
+          value: '-old();\n+new();',
+        },
+      ],
+    ],
+  ]);
+
+  const attached = attachWebSuggestedDiffs(records, suggestions);
+
+  assert.equal(attached, 1);
+  assert.equal(records[0].comments[0].unavailableReason, undefined);
+  assert.equal(records[0].comments[0].suggestedDiffs[0].value, '-old();\n+new();');
 });


### PR DESCRIPTION
## Summary

This PR improves the reliability of the Wallstop PR Comments extension when collecting and rendering suggested changes from GitHub PR review comments.

## User-facing changes

- Suggested changes are now sourced in a safer order: GitHub API markdown suggestions first, then GitHub web PR files parsing, then optional browser HTML fallback.
- Suggested diffs found via web/browser parsing are now only trusted when they come from GitHub automated comment data, reducing false positives from user-authored text.
- Copy output now reports where attached suggested diffs came from, making results easier to understand.
- Adds optional browser fallback support via the user/global setting `wallstopPrComments.browserWebSuggestionsCommand`.
- Improves handling of external bot comments (such as Cursor/Bugbot) so unavailable fixes are clearly labeled instead of being inferred incorrectly.
- Improves embedded location parsing and matching logic for comments so file/line attribution is more consistent.

## Quality and test coverage

- Adds a new extension test suite file and significantly expands parser, web suggestion, GitHub client, and renderer tests.
- Updates extension internals and type contracts to support provenance/confidence metadata and more robust ID matching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes copy/paste output and web HTML/cookie/browser enrichment for PR comments; mistakes could attach wrong suggested diffs or mis-attribute locations, but parsing is intentionally conservative and browser fallback is opt-in.
> 
> **Overview**
> Strengthens **Wallstop PR Comments** when copying PR review threads: suggested fixes are gathered in a fixed trust order (API `suggestion` fences, then GitHub PR `/files` HTML, then an opt-in browser HTML provider), and copy warnings name **where** attached web diffs came from (`githubWebAutomatedDiff`, `browserDomAutomatedDiff`, etc.).
> 
> Adds application-scoped **`wallstopPrComments.browserWebSuggestionsCommand`** so a VS Code command can supply logged-in PR files HTML; only **global** config is honored. **`getWebSuggestedDiffs`** tries unauthenticated fetch first, then sanitized cookie, then browser fallback when enabled; web parsing accepts only **`automatedComment.suggestion.diffEntries`**, with tighter ID matching (numeric/string `databaseId`, discussion URLs) and rejection of forged JSON in comment bodies.
> 
> **Cursor/Bugbot** handling is tightened: exact bot logins via **`botAuthors`**, embedded `LOCATIONS` may override file/line for trusted bots (with mismatch guards), prose cleanup strips bot chrome, and external fixes are labeled **unavailable** instead of inferring diffs from `diffHunk`. Copilot web-only cases use the same conservative unavailable rules. Types and render output gain **source/confidence** metadata and **cross-path** `Suggested change (<path>):` labels. Documentation and tests cover the new contracts end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb3e139bdb85e9b7430368e34e4d6b3515abe91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->