### PR TITLE
Fix TypeScript 7 extension build and advance analyzer lane

### DIFF
--- a/Extensions/WallstopPrComments/package-lock.json
+++ b/Extensions/WallstopPrComments/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "markdown-it": "^14.1.0"
+        "markdown-it": "^15.0.0"
       },
       "devDependencies": {
         "@types/markdown-it": "^14.1.2",
-        "@types/node": "^18.19.112",
-        "@types/vscode": "1.90.0",
-        "typescript": "^5.5.4",
-        "yauzl": "^2.10.0",
-        "yazl": "^2.5.1"
+        "@types/node": "^26.1.2",
+        "@types/vscode": "1.125.0",
+        "typescript": "^7.0.2",
+        "yauzl": "^3.4.0",
+        "yazl": "^3.3.1"
       },
       "engines": {
         "vscode": "^1.90.0"
@@ -46,58 +46,379 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ]
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
       "funding": [
         {
           "type": "github",
@@ -109,13 +430,13 @@
         }
       ],
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^3.0.0"
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
       "funding": [
         {
           "type": "github",
@@ -127,21 +448,21 @@
         }
       ],
       "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
-        "mdurl": "^2.0.0",
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "uc.micro": "^3.0.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -158,46 +479,69 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
       "dev": true,
       "dependencies": {
-        "buffer-crc32": "~0.2.3"
+        "buffer-crc32": "^1.0.0"
       }
     }
   }

--- a/Extensions/WallstopPrComments/package-lock.json
+++ b/Extensions/WallstopPrComments/package-lock.json
@@ -20,7 +20,7 @@
         "yazl": "^3.3.1"
       },
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@types/linkify-it": {

--- a/Extensions/WallstopPrComments/package.json
+++ b/Extensions/WallstopPrComments/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Other"

--- a/Extensions/WallstopPrComments/package.json
+++ b/Extensions/WallstopPrComments/package.json
@@ -176,14 +176,14 @@
     "test": "npm run compile && node scripts/run-tests.js"
   },
   "dependencies": {
-    "markdown-it": "^14.1.0"
+    "markdown-it": "^15.0.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/node": "^18.19.112",
-    "@types/vscode": "1.90.0",
-    "typescript": "^5.5.4",
-    "yauzl": "^2.10.0",
-    "yazl": "^2.5.1"
+    "@types/node": "^26.1.2",
+    "@types/vscode": "1.125.0",
+    "typescript": "^7.0.2",
+    "yauzl": "^3.4.0",
+    "yazl": "^3.3.1"
   }
 }

--- a/Extensions/WallstopPrComments/test/manifest.test.ts
+++ b/Extensions/WallstopPrComments/test/manifest.test.ts
@@ -86,20 +86,27 @@ test('extension runtime floor supports the Node version required by production d
     engines?: { vscode?: string };
   };
   const lockfile = JSON.parse(readFileSync(join(extensionRoot, 'package-lock.json'), 'utf8')) as {
-    packages?: { [key: string]: { engines?: { node?: string } } };
+    packages?: {
+      [key: string]: {
+        dependencies?: { [key: string]: string };
+        engines?: { node?: string };
+      };
+    };
   };
   const workflow = readFileSync(join(repositoryRoot, '.github', 'workflows', 'extension-tests.yml'), 'utf8');
 
-  assert.equal(
-    manifest.engines?.vscode,
-    '^1.101.0',
-    'update this runtime-policy test when the extension VS Code engine floor changes',
-  );
-  assert.equal(
-    lockfile.packages?.['node_modules/entities']?.engines?.node,
-    '>=20.19.0',
-    'the runtime-policy test must track the minimum Node version required by entities',
-  );
+  const vscodeEngineMatch = /^\^(\d+)\.(\d+)\.(\d+)$/u.exec(manifest.engines?.vscode ?? '');
+  assert.ok(vscodeEngineMatch, 'the VS Code engine floor must be a caret semver range');
+  assert.ok(Number(vscodeEngineMatch[2]) >= 101, 'the VS Code floor must provide the modern Node extension host');
+
+  const markdownItPackage = lockfile.packages?.['node_modules/markdown-it'];
+  const entityPackageName = markdownItPackage?.dependencies?.entities;
+  assert.match(entityPackageName ?? '', /^\^\d+\.\d+\.\d+$/u, 'markdown-it must declare a semver entities dependency');
+
+  const entityPackage = lockfile.packages?.[`node_modules/entities`];
+  const nodeEngineMatch = /^>=(\d+)\.(\d+)\.(\d+)$/u.exec(entityPackage?.engines?.node ?? '');
+  assert.ok(nodeEngineMatch, 'the production entity dependency must declare a minimum Node engine');
+  assert.ok(Number(nodeEngineMatch[1]) >= 20, 'the extension must not package an entity dependency requiring an obsolete Node major');
   assert.match(
     workflow,
     /uses:\s*actions\/setup-node@v\d+\.\d+\.\d+/u,

--- a/Extensions/WallstopPrComments/test/manifest.test.ts
+++ b/Extensions/WallstopPrComments/test/manifest.test.ts
@@ -79,18 +79,26 @@ test('package manifest pins refreshRepo inline on repository tree items', () => 
   assert.match(refreshRepoMenu.group ?? '', /^inline(@\d+)?$/u, 'refreshRepo must render inline on the repository node');
 });
 
-test('extension CI runs on the VS Code 1.90 extension-host Node major', () => {
+test('extension runtime floor supports the Node version required by production dependencies', () => {
   const extensionRoot = join(__dirname, '..', '..');
   const repositoryRoot = join(extensionRoot, '..', '..');
   const manifest = JSON.parse(readFileSync(join(extensionRoot, 'package.json'), 'utf8')) as {
     engines?: { vscode?: string };
   };
+  const lockfile = JSON.parse(readFileSync(join(extensionRoot, 'package-lock.json'), 'utf8')) as {
+    packages?: { [key: string]: { engines?: { node?: string } } };
+  };
   const workflow = readFileSync(join(repositoryRoot, '.github', 'workflows', 'extension-tests.yml'), 'utf8');
 
   assert.equal(
     manifest.engines?.vscode,
-    '^1.90.0',
+    '^1.101.0',
     'update this runtime-policy test when the extension VS Code engine floor changes',
+  );
+  assert.equal(
+    lockfile.packages?.['node_modules/entities']?.engines?.node,
+    '>=20.19.0',
+    'the runtime-policy test must track the minimum Node version required by entities',
   );
   assert.match(
     workflow,

--- a/Extensions/WallstopPrComments/tsconfig.json
+++ b/Extensions/WallstopPrComments/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "Node16",
     "lib": [
       "ES2022",
       "DOM"
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "types": [
       "node",
       "vscode"

--- a/PLAN.md
+++ b/PLAN.md
@@ -22,6 +22,7 @@
 - [x] Capture the current analyzer inventory, versions, scopes, warning counts, and intentional suppressions in a reviewable artifact.
 - [x] Select the first lane for warnings-as-errors using the smallest independently verifiable scope.
 - [x] Add a failing baseline test for newly introduced warnings while remediation proceeds separately.
-- [ ] Expand warnings-as-errors lane by lane only after the baseline is green and CI timing remains within contract.
+- [x] Expand warnings-as-errors to the managed ShellCheck lane, preserving its style-level blocking policy and wrapper failure diagnostic.
+- [ ] Expand warnings-as-errors to the managed native analyzer lane only after the shell lane remains green in CI.
 
-Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md). The first lane is the 77-target PowerShell ScriptAnalyzer scope because it already has a deterministic zero-finding gate and does not require changing the shell/native release-tool lanes.
+Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md) and [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md). The PowerShell ScriptAnalyzer scope and managed ShellCheck lane now have explicit fail-closed policy coverage; the native lane remains separately gated to preserve CI timing.

--- a/Tests/Utils/Invoke-ShellQualityChecks.Tests.ps1
+++ b/Tests/Utils/Invoke-ShellQualityChecks.Tests.ps1
@@ -92,8 +92,8 @@ Describe "Invoke-ShellQualityChecks target scoping" {
         { Invoke-ShellQualityChecksMain -SelectedTool All -ApplyFix:$false -OnlyEnsureTools:$false -InputFiles @("does-not-exist.sh") } |
             Should -Not -Throw
 
-        Assert-MockCalled -CommandName Read-ShellQualityToolManifest -Times 0 -Exactly
-        Assert-MockCalled -CommandName Resolve-ShellQualityToolExecutable -Times 0 -Exactly
+        Should -Invoke Read-ShellQualityToolManifest -Times 0 -Exactly
+        Should -Invoke Resolve-ShellQualityToolExecutable -Times 0 -Exactly
     }
 
     It "skips existing non-shell targets before reading the manifest or resolving tools" {
@@ -105,10 +105,10 @@ Describe "Invoke-ShellQualityChecks target scoping" {
         { Invoke-ShellQualityChecksMain -SelectedTool shfmt -ApplyFix:$false -OnlyEnsureTools:$false -InputFiles @("README.md") } |
             Should -Not -Throw
 
-        Assert-MockCalled -CommandName Read-ShellQualityToolManifest -Times 0 -Exactly
-        Assert-MockCalled -CommandName Resolve-ShellQualityToolExecutable -Times 0 -Exactly
-        Assert-MockCalled -CommandName Invoke-ShfmtQualityCheck -Times 0 -Exactly
-        Assert-MockCalled -CommandName Invoke-ShellCheckQualityCheck -Times 0 -Exactly
+        Should -Invoke Read-ShellQualityToolManifest -Times 0 -Exactly
+        Should -Invoke Resolve-ShellQualityToolExecutable -Times 0 -Exactly
+        Should -Invoke Invoke-ShfmtQualityCheck -Times 0 -Exactly
+        Should -Invoke Invoke-ShellCheckQualityCheck -Times 0 -Exactly
     }
 
     It "still resolves all requested tools in EnsureOnly mode" {
@@ -159,6 +159,24 @@ Describe "Invoke-ShellQualityChecks bounded process execution" {
         }
 
         $elapsed.TotalSeconds | Should -BeLessThan 25
+    }
+}
+
+Describe "Invoke-ShellQualityChecks warnings-as-errors lane" {
+    It "keeps ShellCheck style findings blocking" {
+        $configPath = Join-Path -Path $script:repoRoot -ChildPath ".shellcheckrc"
+        $config = (Get-Content -LiteralPath $configPath -Raw) -replace "`r", ''
+
+        $config | Should -Match '(?m)^severity\s*=\s*style\s*$'
+    }
+
+    It "fails closed when ShellCheck reports a finding" {
+        Mock Invoke-QualityToolingProcess { return 1 }
+
+        $targetPath = Join-Path -Path $script:repoRoot -ChildPath ".devcontainer/post-create.sh"
+        {
+            Invoke-ShellCheckQualityCheck -ExecutablePath "/tmp/shellcheck" -RepositoryRoot $script:repoRoot -Files @($targetPath)
+        } | Should -Throw -ExpectedMessage "*E_SHELLCHECK_FAILED*"
     }
 }
 

--- a/progress/session-005-dependency-and-shell-lane.md
+++ b/progress/session-005-dependency-and-shell-lane.md
@@ -1,0 +1,21 @@
+# Session 005: dependency repair and shell analyzer lane
+
+## Findings
+
+- Open PR #40 was not green: its extension test failed because TypeScript 7 removed the legacy `moduleResolution: "node"` (`node10`) setting.
+- Main had no draft or in-progress PRs. The current `main` CI run was green except for the still-running PowerShell 7 job; the open issues remain #43 and #46.
+- The repository already configured ShellCheck with `severity=style`, but its fail-closed behavior was not directly covered by the shell wrapper test suite.
+
+## Changes
+
+- Carried the dependency updates from PR #40 into the current branch.
+- Updated the extension compiler configuration to the TypeScript 7-compatible `Node16` module and `node16` module-resolution pair.
+- Regenerated `Extensions/WallstopPrComments/package-lock.json` with the upgraded dependency graph.
+- Added regression coverage proving ShellCheck style findings remain blocking and non-zero execution produces `E_SHELLCHECK_FAILED`.
+- Advanced `PLAN.md` to mark the managed ShellCheck lane complete and keep native analyzer expansion as the next separately verified lane.
+
+## Verification
+
+- `npm ci --ignore-scripts` completed with the regenerated lockfile.
+- `npm test` passed: 277 tests, 0 failures, using the TypeScript 7 compiler.
+- The previous PR #40 compiler failure was reproduced before the `tsconfig.json` repair and is resolved by the new configuration.

--- a/progress/session-006-runtime-floor-review.md
+++ b/progress/session-006-runtime-floor-review.md
@@ -1,0 +1,17 @@
+# Session 006: runtime-floor review correction
+
+## Finding
+
+Cursor Bugbot identified that the TypeScript 7 dependency graph brings `entities@8`, whose Node engine requirement is newer than the extension's previous VS Code `^1.90.0` runtime floor.
+
+## Changes
+
+- Raised the extension runtime floor to the VS Code release line that provides the modern Node extension host.
+- Reworked the runtime-policy test to validate semver shape and compatibility floors instead of asserting exact dependency or engine versions, keeping Dependabot upgrades test-independent.
+- Derived the `entities` dependency range from `markdown-it`'s lockfile entry and validated its declared Node engine contract.
+
+## Verification
+
+- `npm test`: 277 passing.
+- Staged pre-commit checks passed.
+- PR #51 required CI lanes passed, including extension compilation/tests, PowerShell 5.1/7, pre-commit, compatibility, Windows, macOS, and devcontainer validation.


### PR DESCRIPTION
## Summary

- Carry the grouped Wallstop PR Comments dependency upgrades into a current-main branch.
- Update the TypeScript compiler configuration for TypeScript 7's Node16 module-resolution contract.
- Add fail-closed ShellCheck warnings-as-errors regression coverage and advance PLAN.md.

## Verification

- `npm ci --ignore-scripts`
- `npm test` (277 passing)
- Repository preflight passed
- Targeted shell-quality Pester gate passed
- Staged-target pre-commit validation passed through the managed pre-commit CLI

This supersedes the compile failure in dependency PR #40 caused by the removed legacy `moduleResolution: node` setting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the extension’s minimum VS Code version and changes compile/module resolution; runtime and markdown rendering should be smoke-tested on supported VS Code builds.
> 
> **Overview**
> Fixes the **Wallstop PR Comments** extension build after upgrading to **TypeScript 7** and refreshed dependencies (including **markdown-it 15**). Compiler settings move from legacy CommonJS/`node` resolution to **`module: Node16`** and **`moduleResolution: node16`**, matching TS 7’s requirements and resolving the failure seen on dependency PR #40.
> 
> The extension’s **minimum VS Code engine** is raised to **`^1.101.0`** so the packaged **Node/extension host** can satisfy production deps (notably **`entities@8`** via markdown-it). The runtime-policy test no longer pins exact engine versions; it checks semver floors, markdown-it’s **entities** chain, and that CI still exercises **Node 20**.
> 
> On the analyzer milestone, **PLAN.md** marks the managed **ShellCheck** warnings-as-errors lane complete. New Pester coverage asserts **`.shellcheckrc`** keeps **`severity=style`** and that non-zero ShellCheck runs throw **`E_SHELLCHECK_FAILED`**. Existing shell-quality tests switch mock assertions to **`Should -Invoke`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb88526e1890f40dafca2f54f0584c8c96af6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->