### PR TITLE
Advance TypeScript warnings-as-errors lane

### DIFF
--- a/Extensions/WallstopPrComments/test/manifest.test.ts
+++ b/Extensions/WallstopPrComments/test/manifest.test.ts
@@ -35,6 +35,16 @@ test('package manifest routes npm test through the cross-platform test runner', 
   assert.equal(manifest.scripts?.test, 'npm run compile && node scripts/run-tests.js');
 });
 
+test('TypeScript compiler keeps unused declarations as errors', () => {
+  const extensionRoot = join(__dirname, '..', '..');
+  const compilerConfig = JSON.parse(readFileSync(join(extensionRoot, 'tsconfig.json'), 'utf8')) as {
+    compilerOptions?: { noUnusedLocals?: boolean; noUnusedParameters?: boolean };
+  };
+
+  assert.equal(compilerConfig.compilerOptions?.noUnusedLocals, true);
+  assert.equal(compilerConfig.compilerOptions?.noUnusedParameters, true);
+});
+
 test('package manifest declares opt-out auto-refresh settings (enabled by default)', () => {
   const extensionRoot = join(__dirname, '..', '..');
   const manifest = JSON.parse(readFileSync(join(extensionRoot, 'package.json'), 'utf8')) as {

--- a/Extensions/WallstopPrComments/tsconfig.json
+++ b/Extensions/WallstopPrComments/tsconfig.json
@@ -9,6 +9,8 @@
     "outDir": "out",
     "rootDir": ".",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,7 @@
 - [x] Add a failing baseline test for newly introduced warnings while remediation proceeds separately.
 - [x] Expand warnings-as-errors to the managed ShellCheck lane, preserving its style-level blocking policy and wrapper failure diagnostic.
 - [x] Expand warnings-as-errors to the managed native analyzer lane with fail-closed StyLua/actionlint regression coverage.
+- [x] Expand warnings-as-errors to the TypeScript extension compiler with unused-local and unused-parameter checks.
 
 Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), and [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md). The PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, and actionlint lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@
 ## Follow-up
 
 - Issue #46 (partial git uploads) now has explicit post-push remote-head verification and commit wording that distinguishes failed backup steps from Git publication. A live backup run remains required to close the operational investigation safely.
-- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed PowerShell, ShellCheck/shfmt, StyLua, and actionlint lanes now have deterministic enforcement documented in sessions 004–007.
+- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007 and 013.
 
 ## Next milestone: analyzer baseline for #43
 
@@ -28,6 +28,6 @@
 - [x] Expand warnings-as-errors to the managed native analyzer lane with fail-closed StyLua/actionlint regression coverage.
 - [x] Expand warnings-as-errors to the TypeScript extension compiler with unused-local and unused-parameter checks.
 
-Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), and [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md). The PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, and actionlint lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
+Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md), and [session-013 TypeScript analyzer lane](./progress/session-013-typescript-analyzer-lane.md). The PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, actionlint, and TypeScript compiler lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
 
 Evidence for the host-state snapshot: [session-008 config snapshot](./progress/session-008-config-snapshot.md), [session-010 backup host-state audit](./progress/session-010-backup-host-state-audit.md), [session-011 backup host-state runbook](./progress/session-011-backup-host-state-runbook.md), and [session-012 verified snapshot](./progress/session-012-verified-host-state-snapshot.md).

--- a/progress/session-013-typescript-analyzer-lane.md
+++ b/progress/session-013-typescript-analyzer-lane.md
@@ -11,12 +11,14 @@ tool, dependency, or CI lane.
 
 - Enabled `noUnusedLocals` and `noUnusedParameters` in the extension's
   `tsconfig.json`.
+- Added a manifest-suite regression test so the warning-as-error settings
+  cannot be removed while the compile still passes.
 - Updated `PLAN.md` to record the completed TypeScript compiler lane.
 
 ## Verification
 
-- `npx tsc -p tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters`
-  passed against the current extension sources.
+- `npm test` passed: 278 tests, including compilation and the configuration
+  regression test.
 - The existing extension workflow's `npm test` command exercises the same
   compiler configuration, so the new checks are part of the required CI gate.
 

--- a/progress/session-013-typescript-analyzer-lane.md
+++ b/progress/session-013-typescript-analyzer-lane.md
@@ -1,0 +1,28 @@
+# Session 013: TypeScript analyzer lane
+
+## Scope
+
+Advance issue #43 by making the extension compiler fail closed on unused
+locals and parameters. The extension already compiles with `strict: true`, so
+these checks add useful warnings-as-errors coverage without introducing a new
+tool, dependency, or CI lane.
+
+## Changes
+
+- Enabled `noUnusedLocals` and `noUnusedParameters` in the extension's
+  `tsconfig.json`.
+- Updated `PLAN.md` to record the completed TypeScript compiler lane.
+
+## Verification
+
+- `npx tsc -p tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters`
+  passed against the current extension sources.
+- The existing extension workflow's `npm test` command exercises the same
+  compiler configuration, so the new checks are part of the required CI gate.
+
+## Remaining issue #43 scope
+
+The repository still has configuration/data surfaces and platform-specific
+languages that are intentionally outside the managed analyzer lanes. They
+remain candidates for separately scoped inventory work rather than being
+silently widened into the fast PR gate.

--- a/progress/session-014-pr57-audit.md
+++ b/progress/session-014-pr57-audit.md
@@ -1,0 +1,27 @@
+# Session 014: PR #57 audit and analyzer regression coverage
+
+## Changes
+
+- Added extension test coverage that asserts `noUnusedLocals` and
+  `noUnusedParameters` remain enabled in `tsconfig.json`.
+- Updated `PLAN.md` to link the TypeScript lane evidence and include it in the
+  managed analyzer inventory.
+- Advanced PR #57 with commit `9db993d`.
+
+## Verification
+
+- Extension suite: 278 tests passed.
+- `Invoke-FullValidation.ps1 -PreflightOnly`: passed.
+- PR #57 required checks: Script Quality, Devcontainer Validate, extension
+  tests, Windows language checks, macOS validation, compatibility, and both
+  PowerShell runtime lanes all passed.
+- Cursor Bugbot passed. Copilot review remains a non-actionable quota failure
+  with no review threads or requested changes.
+
+## Remaining open issues
+
+- Issue #43 still needs broader analyzer inventory and additional justified
+  lanes beyond the managed script, native, and TypeScript surfaces.
+- Issue #46 still needs one live Windows backup run with transport diagnostics;
+  repository history and post-push remote-head verification establish that
+  prior commits were atomic but cannot replace that operational evidence.


### PR DESCRIPTION
## Summary

- Enable TypeScript `noUnusedLocals` and `noUnusedParameters` in the extension compiler.
- Advance `PLAN.md` for issue #43 and record session evidence.

## Verification

- `npm test` — 277 tests passed.
- `npx tsc -p tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters` — passed.
- `Invoke-FullValidation.ps1 -PreflightOnly` — passed.
- `git diff --cached --check` — passed.

This keeps the change scoped to the existing extension CI compile gate; no new dependency or CI lane is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time TypeScript strictness and documentation only; no auth, runtime, or dependency changes beyond failing compile on unused symbols.
> 
> **Overview**
> Extends issue **#43** warnings-as-errors by turning on **`noUnusedLocals`** and **`noUnusedParameters`** in the Wallstop PR Comments extension **`tsconfig.json`**, so unused code fails the existing **`npm test`** compile step instead of needing a new CI lane.
> 
> A manifest-suite test asserts those compiler flags stay enabled, and **`PLAN.md`** plus session notes (**013**/**014**) record the TypeScript analyzer lane as complete alongside the other managed lanes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312ea627a98375a6e8ef73ae9418627a9dfab2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->