### PR TITLE
Expand production PowerShell analyzer coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         name: powershell-precommit-validation
         entry: pwsh -NoLogo -NoProfile -File Scripts/Utils/Run-PreCommitValidation.ps1
         language: system
-        files: '^(Scripts/(Utils|Komorebi)/.*\.ps1|Tests/Utils/.*\.Tests\.ps1|Tests/GitHub/.*\.ps1|Config/Powershell/.*\.ps1|Scripts/AutoHotKey/.*\.ahk|Config/\.config/.*\.ahk|Scripts/.*\.bat|Scripts/.*\.sh|\.devcontainer/.*\.sh|\.githooks/(pre-commit|pre-push)|Config/Wezterm/wezterm\.lua|\.github/workflows/.*\.(yml|yaml)|\.llm/.*\.md|AGENTS\.md|CLAUDE\.md|\.github/copilot-instructions\.md|\.github/dependabot\.yml|\.pre-commit-config\.yaml|\.gitattributes|\.editorconfig|\.gitignore|requirements\.txt|\.psscriptanalyzer(\.format)?\.psd1|\.shellcheckrc|\.stylua\.toml|Scripts/Utils/Quality/(native-quality-tools|shell-quality-tools|precommit-cli-tools)\.json)$'
+        files: '^(Scripts/.*\.ps1|Tests/Utils/.*\.Tests\.ps1|Tests/GitHub/.*\.ps1|Config/Powershell/.*\.ps1|Scripts/AutoHotKey/.*\.ahk|Config/\.config/.*\.ahk|Scripts/.*\.bat|Scripts/.*\.sh|\.devcontainer/.*\.sh|\.githooks/(pre-commit|pre-push)|Config/Wezterm/wezterm\.lua|\.github/workflows/.*\.(yml|yaml)|\.llm/.*\.md|AGENTS\.md|CLAUDE\.md|\.github/copilot-instructions\.md|\.github/dependabot\.yml|\.pre-commit-config\.yaml|\.gitattributes|\.editorconfig|\.gitignore|requirements\.txt|\.psscriptanalyzer(\.format)?\.psd1|\.shellcheckrc|\.stylua\.toml|Scripts/Utils/Quality/(native-quality-tools|shell-quality-tools|precommit-cli-tools)\.json)$'
         pass_filenames: false
         stages: [pre-commit]
       - id: powershell-prepush-validation

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@
 ## Follow-up
 
 - Issue #46 (partial git uploads) now has explicit post-push remote-head verification and commit wording that distinguishes failed backup steps from Git publication. A live backup run remains required to close the operational investigation safely.
-- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007 and 013.
+- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed production PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, and 015.
 
 ## Next milestone: analyzer baseline for #43
 
@@ -27,7 +27,8 @@
 - [x] Expand warnings-as-errors to the managed ShellCheck lane, preserving its style-level blocking policy and wrapper failure diagnostic.
 - [x] Expand warnings-as-errors to the managed native analyzer lane with fail-closed StyLua/actionlint regression coverage.
 - [x] Expand warnings-as-errors to the TypeScript extension compiler with unused-local and unused-parameter checks.
+- [x] Expand PowerShell warnings-as-errors to all tracked production scripts under `Scripts/` with staged-file targeting preserved for fast hooks.
 
-Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md), and [session-013 TypeScript analyzer lane](./progress/session-013-typescript-analyzer-lane.md). The PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, actionlint, and TypeScript compiler lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
+Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md), [session-013 TypeScript analyzer lane](./progress/session-013-typescript-analyzer-lane.md), and [session-015 production PowerShell lane](./progress/session-015-production-powershell-lane.md). The production PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, actionlint, and TypeScript compiler lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
 
 Evidence for the host-state snapshot: [session-008 config snapshot](./progress/session-008-config-snapshot.md), [session-010 backup host-state audit](./progress/session-010-backup-host-state-audit.md), [session-011 backup host-state runbook](./progress/session-011-backup-host-state-runbook.md), and [session-012 verified snapshot](./progress/session-012-verified-host-state-snapshot.md).

--- a/Scripts/Utils/Run-PreCommitValidation.ps1
+++ b/Scripts/Utils/Run-PreCommitValidation.ps1
@@ -1475,7 +1475,7 @@ try {
     $githubTestPattern = '^(Scripts/Utils/GitHub|Tests/GitHub)/.+\.ps1$'
     $komorebiProfilePattern = '^(Scripts/Komorebi/.+\.ps1|Tests/Utils/KomorebiProfileHelpers\.Tests\.ps1)$'
     $komorebiPolicyPattern = '^(Scripts/Komorebi/.+\.ps1|Scripts/Utils/Run-PreCommitValidation\.ps1|Tests/Utils/ScriptSafetyConventions\.Tests\.ps1|\.pre-commit-config\.yaml)$'
-    $scriptPattern = '^(Scripts/Utils|Scripts/Komorebi)/.+\.ps1$'
+    $scriptPattern = '^Scripts/.+\.ps1$'
     $shellQualityPattern = '^(Scripts/.+\.sh|\.devcontainer/.+\.sh|\.githooks/(pre-commit|pre-push))$'
     $shellSafetyTriggerPattern = '^(Scripts/.+\.sh|\.devcontainer/.+\.sh|\.githooks/(pre-commit|pre-push)|Tests/Utils/ScriptSafetyConventions\.Tests\.ps1)$'
     $nativeQualityPattern = '^(Config/Wezterm/wezterm\.lua|\.github/workflows/.+\.(yml|yaml))$'
@@ -1575,7 +1575,7 @@ try {
 
     $analyzerTargets = @()
     if ($All) {
-        $analyzerTargets = @("Scripts/Utils")
+        $analyzerTargets = @("Scripts")
     }
     elseif ($scriptFiles.Count -gt 0) {
         $missingAnalyzerTargets = @(

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -1771,7 +1771,7 @@ Describe "Cross-language quality platform conventions" {
         $validatorContent | Should -Match 'PreCommitKomorebiPolicy'
         $validatorContent | Should -Match 'Skipping Tests/Utils Pester suite for script-only staged changes in fast local mode'
         $validatorContent | Should -Match 'full suite remains enforced in -All/full validation'
-        $preCommitConfig | Should -Match 'Scripts/\(Utils\|Komorebi\)/\.\*\\\.ps1'
+        $preCommitConfig | Should -Match 'Scripts/\.\*\\\.ps1'
     }
 
     It "routes native Lua and workflow checks through the precommit orchestrator" {
@@ -5242,12 +5242,12 @@ Set-PortableProcessEnvironmentVariable -StartInfo $startInfo -Name "PATH" -Value
         $outsideRepoGuardIndex | Should -BeLessThan $writeIndex -Because 'Outside-repository guard must execute before writing the artifact file.'
     }
 
-    It "scopes ScriptAnalyzer targets to staged Scripts/Utils files unless -All is used" {
+    It "scopes ScriptAnalyzer targets to staged Scripts files unless -All is used" {
         $preCommitPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Run-PreCommitValidation.ps1"
         $content = (Get-Content -Path $preCommitPath -Raw) -replace "`r", ''
 
         $content | Should -Match '\$analyzerTargets\s*=\s*@\(\)'
-        $content | Should -Match 'if\s*\(\$All\)\s*\{\s*\$analyzerTargets\s*=\s*@\("Scripts/Utils"\)'
+        $content | Should -Match 'if\s*\(\$All\)\s*\{\s*\$analyzerTargets\s*=\s*@\("Scripts"\)'
         $content | Should -Match 'elseif\s*\(\$scriptFiles\.Count\s*-gt\s*0\)'
         $content | Should -Match 'Write-Verbose\s*\(\s*"ScriptAnalyzer staged-path diagnostics: skippedMissingCount='
         $content | Should -Match '\$analyzerTargets\s*=\s*@\(\s*\$scriptFiles\s*\|\s*Where-Object\s*\{\s*Test-Path\s*-LiteralPath\s*\$_\s*-PathType\s*Leaf\s*\}\s*\|\s*Sort-Object\s*-Unique\s*\)'

--- a/progress/session-015-production-powershell-lane.md
+++ b/progress/session-015-production-powershell-lane.md
@@ -1,0 +1,32 @@
+# Session 015: production PowerShell analyzer lane
+
+## Scope
+
+Advance issue #43 by covering every tracked production PowerShell script under
+`Scripts/` with the existing PSScriptAnalyzer warnings-as-errors lane. Test
+fixtures remain outside this production lane because their current baseline
+contains intentional/generated mock data that requires a separate remediation
+scope.
+
+## Changes
+
+- Changed full validation from `Scripts/Utils` to the complete `Scripts`
+  production tree.
+- Changed staged analyzer targeting from only `Scripts/Utils` and
+  `Scripts/Komorebi` to all existing `Scripts/**/*.ps1` paths.
+- Expanded the pre-commit validation trigger to cover all `Scripts/**/*.ps1`
+  files while retaining staged-file fast-path behavior.
+- Updated structural policy coverage and `PLAN.md`.
+
+## Verification
+
+- PSScriptAnalyzer 1.21.0 over 58 tracked production scripts: 0 findings.
+- Compatibility gate over the changed validator and policy test: pass, 0
+  findings.
+- ScriptSafetyConventions Pester gate completed successfully.
+
+## Remaining issue #43 scope
+
+PowerShell test fixtures, encrypted/configuration snapshots, and platform
+languages still need inventory or separately justified lanes. They are not
+silently folded into this production-script gate.


### PR DESCRIPTION
## Summary

- Extend the existing PSScriptAnalyzer warnings-as-errors lane to all tracked production scripts under `Scripts/`.
- Preserve staged-file targeting for fast local hooks.
- Update policy coverage and analyzer progress evidence.

## Evidence

- PSScriptAnalyzer 1.21.0 over 58 production scripts: 0 findings.
- Compatibility gate for the changed validator/policy test: pass, 0 findings.
- ScriptSafetyConventions Pester gate: passed.
- Existing dependencies and CI lanes are unchanged.

Test fixtures and encrypted/configuration snapshots remain explicitly outside this production lane for separately scoped remediation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens pre-commit and full-validation gates to more production PowerShell; mis-scoped patterns or latent analyzer issues could block commits, though the PR reports a clean baseline on 58 scripts.
> 
> **Overview**
> **Extends the existing PSScriptAnalyzer warnings-as-errors lane** from `Scripts/Utils` (and the prior `Scripts/Komorebi` staged subset) to **every tracked production script under `Scripts/**/*.ps1`**, while keeping fast local hooks that only analyze staged script paths unless full `-All` validation runs.
> 
> `Run-PreCommitValidation.ps1` widens `$scriptPattern` to `^Scripts/.+\.ps1$`, sets full-mode analyzer roots to `Scripts`, and the **powershell-precommit-validation** hook’s `files` regex now matches any `Scripts/**/*.ps1` so changes outside Utils/Komorebi still trigger validation. **ScriptSafetyConventions** tests and **PLAN.md** are updated to match; **session-015** documents scope and verification (58 production scripts, 0 findings). Test fixtures under `Tests/` stay outside this lane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f171da133ec09dc5c77d4e54f6321b307cb195f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->