### PR TITLE
Remediate PowerShell test analyzer findings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@
 ## Follow-up
 
 - Issue #46 (partial git uploads) now has explicit post-push remote-head verification and commit wording that distinguishes failed backup steps from Git publication. A live backup run remains required to close the operational investigation safely.
-- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed production PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, and 015. The remaining PowerShell test-fixture findings are tracked separately in issue #59.
+- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed production and test PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, 015, and 017.
 
 ## Next milestone: analyzer baseline for #43
 
@@ -28,8 +28,8 @@
 - [x] Expand warnings-as-errors to the managed native analyzer lane with fail-closed StyLua/actionlint regression coverage.
 - [x] Expand warnings-as-errors to the TypeScript extension compiler with unused-local and unused-parameter checks.
 - [x] Expand PowerShell warnings-as-errors to all tracked production scripts under `Scripts/` with staged-file targeting preserved for fast hooks.
-- [ ] Characterize and safely govern the dynamic Pester-fixture analyzer surface tracked in issue #59 without weakening the production `Scripts/` lane.
+- [x] Characterize and safely govern the dynamic Pester-fixture analyzer surface tracked in issue #59 without weakening the production `Scripts/` lane.
 
-Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md), [session-013 TypeScript analyzer lane](./progress/session-013-typescript-analyzer-lane.md), [session-015 production PowerShell lane](./progress/session-015-production-powershell-lane.md), and [session-016 test-fixture inventory](./progress/session-016-test-fixture-inventory.md). The production PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, actionlint, and TypeScript compiler lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
+Evidence: [session-004 analyzer baseline](./progress/session-004-analyzer-baseline.md), [session-005 dependency and shell lane](./progress/session-005-dependency-and-shell-lane.md), [session-007 native analyzer lane](./progress/session-007-native-analyzer-lane.md), [session-013 TypeScript analyzer lane](./progress/session-013-typescript-analyzer-lane.md), [session-015 production PowerShell lane](./progress/session-015-production-powershell-lane.md), [session-016 test-fixture inventory](./progress/session-016-test-fixture-inventory.md), and [session-017 test-fixture remediation](./progress/session-017-test-fixture-remediation.md). The production and test PowerShell ScriptAnalyzer, managed ShellCheck, StyLua, actionlint, and TypeScript compiler lanes now have explicit fail-closed coverage; native checks remain separately gated to preserve CI timing.
 
 Evidence for the host-state snapshot: [session-008 config snapshot](./progress/session-008-config-snapshot.md), [session-010 backup host-state audit](./progress/session-010-backup-host-state-audit.md), [session-011 backup host-state runbook](./progress/session-011-backup-host-state-runbook.md), and [session-012 verified snapshot](./progress/session-012-verified-host-state-snapshot.md).

--- a/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
+++ b/Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1
@@ -5540,7 +5540,34 @@ function Test-ShouldUseFastExit {
 
 function Invoke-Main {
     [CmdletBinding()]
-    param()
+    param(
+        [string]$PullRequestUrl,
+        [string]$Owner,
+        [string]$Repo,
+        [string]$GitHubHost = "github.com",
+        [string[]]$AllowedGitHubHosts = @(),
+        [int]$PullRequestNumber,
+        [string]$Token,
+        [string]$GitHubWebCookie,
+        [ValidateSet("text", "json")]
+        [string]$OutputFormat = "text",
+        [string]$OutputPath,
+        [switch]$Interactive,
+        [switch]$WaitOnRateLimit,
+        [switch]$Truncate,
+        [switch]$KeepMarkup,
+        [switch]$Copy,
+        [switch]$CopyStrict,
+        [switch]$NoFastExit,
+        [ValidateRange(1, 100)]
+        [int]$PerPage = 100,
+        [ValidateRange(1, 100)]
+        [int]$MaxPages = 100,
+        [ValidateRange(5, 300)]
+        [int]$RequestTimeoutSeconds = 60,
+        [ValidateRange(30, 3600)]
+        [int]$OverallTimeoutSeconds = 300
+    )
 
     # Suppress the web-cmdlet progress UI for the whole run. PowerShell's Invoke-WebRequest /
     # Invoke-RestMethod render a progress bar that hides the cursor and emits DSR cursor-position
@@ -5779,7 +5806,7 @@ function Invoke-Main {
 # Allow tests to dot-source without executing main flow.
 if (-not $NoRun.IsPresent -and $MyInvocation.InvocationName -ne ".") {
     try {
-        Invoke-Main
+        Invoke-Main @script:TopLevelBoundParameters
         # By default the process terminates immediately after a successful run, skipping the slow
         # .NET/PowerShell managed teardown (finalizers + HTTP connection-pool shutdown) that
         # dominates wall time on slow container filesystems. Output is already rendered and flushed

--- a/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
+++ b/Tests/GitHub/Get-UnresolvedPRComments.Tests.ps1
@@ -4,6 +4,35 @@ $ErrorActionPreference = "Stop"
 BeforeAll {
     . "$PSScriptRoot/../../Scripts/Utils/Common/CompatibilityHelpers.ps1"
     . "$PSScriptRoot/../../Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1" -NoRun
+
+    function Invoke-TestMain {
+        param(
+            [AllowNull()]
+            [string]$PullRequestUrl,
+            [AllowNull()]
+            [string]$Owner,
+            [AllowNull()]
+            [string]$Repo,
+            [string]$GitHubHost,
+            [string[]]$AllowedGitHubHosts,
+            [int]$PullRequestNumber,
+            [AllowNull()]
+            [string]$Token,
+            [string]$OutputFormat,
+            [bool]$Interactive,
+            [bool]$WaitOnRateLimit,
+            [int]$PerPage,
+            [int]$MaxPages,
+            [int]$RequestTimeoutSeconds,
+            [int]$OverallTimeoutSeconds,
+            [string]$OutputPath,
+            [bool]$Truncate,
+            [bool]$Copy,
+            [bool]$CopyStrict
+        )
+
+        Invoke-Main -PullRequestUrl $PullRequestUrl -Owner $Owner -Repo $Repo -GitHubHost $GitHubHost -AllowedGitHubHosts $AllowedGitHubHosts -PullRequestNumber $PullRequestNumber -Token $Token -OutputFormat $OutputFormat -Interactive:$Interactive -WaitOnRateLimit:$WaitOnRateLimit -PerPage $PerPage -MaxPages $MaxPages -RequestTimeoutSeconds $RequestTimeoutSeconds -OverallTimeoutSeconds $OverallTimeoutSeconds -OutputPath $OutputPath -Truncate:$Truncate -Copy:$Copy -CopyStrict:$CopyStrict
+    }
 }
 
 Describe "Parse-GitHubPullRequestUrl" {
@@ -3577,8 +3606,7 @@ Describe "Invoke-GitHubRequestWithRetry" {
     It "returns null instead of throwing when the shared web session type is unavailable" {
         Mock Resolve-WebRequestSessionType { $null }
 
-        $session = $null
-        { $session = New-GitHubWebSession } | Should -Not -Throw
+        $session = New-GitHubWebSession
         $session | Should -BeNullOrEmpty
     }
 
@@ -4800,7 +4828,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Match "src/main.ts"
         Should -Invoke Validate-GitHubTokenForRepoAccess -Times 1 -Scope It -ParameterFilter { $RequestTimeoutSeconds -eq 60 }
@@ -4858,7 +4886,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "public fallback"
         Should -Invoke Get-PublicPullRequestReviewCommentsFallback -Times 1 -Scope It
@@ -4942,7 +4970,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:authTokenCallCount | Should -Be 2
         $script:reviewCallCount | Should -Be 1
@@ -5022,7 +5050,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:authTokenCallCount | Should -Be 2
         $script:reviewCallCount | Should -Be 1
@@ -5113,7 +5141,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:authTokenCallCount | Should -Be 2
         $script:validateCallCount | Should -Be 2
@@ -5210,7 +5238,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "rate-limit recovered"
         $script:authTokenCallCount | Should -Be 2
@@ -5332,7 +5360,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "recovered with fresh token"
         $script:authTokenCallCount | Should -Be 2
@@ -5428,7 +5456,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "interactive recovered"
         $script:authTokenCallCount | Should -Be 2
@@ -5481,7 +5509,7 @@ Describe "Invoke-Main" {
         Mock Get-UnresolvedReviewThreads { throw "Get-UnresolvedReviewThreads should not be called when token validation fails." }
         Mock Get-PublicPullRequestReviewCommentsFallback { throw "Public REST fallback should not be called when an explicit token fails in direct mode." }
 
-        { Invoke-Main } | Should -Throw "*E_AUTH_INVALID*"
+        { Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds } | Should -Throw "*E_AUTH_INVALID*"
         Should -Invoke Get-GitHubHeaders -Times 1 -Scope It -ParameterFilter { $AuthToken -eq "bad-token" }
         Should -Invoke Get-GitHubHeaders -Times 1 -Scope It -ParameterFilter { [string]::IsNullOrWhiteSpace($AuthToken) }
         Should -Invoke Read-TerminalResponse -Times 0 -Scope It
@@ -5584,7 +5612,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "direct public fallback"
         $script:authTokenCallCount | Should -Be 2
@@ -5676,7 +5704,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "direct rate-limit fallback"
         $script:authTokenCallCount | Should -Be 2
@@ -5757,7 +5785,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
 
         $script:lastOutput | Should -Be "anonymous success"
         Should -Invoke Get-GitHubHeaders -Times 1 -Scope It -ParameterFilter { $AuthToken -eq "expired-token" }
@@ -5832,7 +5860,7 @@ Describe "Invoke-Main" {
         }
         Mock Get-UnresolvedReviewThreads { throw "Get-UnresolvedReviewThreads should not be called for non-auth REST fallback failures." }
 
-        { Invoke-Main } | Should -Throw "*E_NETWORK_TIMEOUT*Public REST fallback timed out*"
+        { Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds } | Should -Throw "*E_NETWORK_TIMEOUT*Public REST fallback timed out*"
         $script:authTokenCallCount | Should -Be 2
         $script:validateCallCount | Should -Be 1
         Should -Invoke Read-TerminalResponse -Times 0 -Scope It
@@ -5892,7 +5920,7 @@ Describe "Invoke-Main" {
         Mock Get-PublicPullRequestReviewCommentsFallback { throw "E_NETWORK_TIMEOUT: Public REST fallback timed out" }
         Mock Get-UnresolvedReviewThreads { throw "Get-UnresolvedReviewThreads should not be called for non-auth REST fallback failures." }
 
-        { Invoke-Main } | Should -Throw "*E_NETWORK_TIMEOUT*"
+        { Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds } | Should -Throw "*E_NETWORK_TIMEOUT*"
         $script:authTokenCallCount | Should -Be 2
         Should -Invoke Read-TerminalResponse -Times 0 -Scope It
         Should -Invoke Get-UnresolvedReviewThreads -Times 0 -Scope It
@@ -5952,7 +5980,7 @@ Describe "Invoke-Main" {
 
         $thrownMessage = $null
         try {
-            Invoke-Main
+            Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds
         }
         catch {
             $thrownMessage = $_.Exception.Message
@@ -5995,7 +6023,7 @@ Describe "Invoke-Main" {
         Mock Get-PublicPullRequestReviewCommentsFallback { throw "E_NOT_FOUND: Public REST fallback could not read this PR" }
         Mock Read-TerminalResponse { "y" }
 
-        { Invoke-Main } | Should -Throw "*E_AUTH_REQUIRED*"
+        { Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds } | Should -Throw "*E_AUTH_REQUIRED*"
         Should -Invoke Read-TerminalResponse -Times 0 -Scope It
     }
 
@@ -6048,7 +6076,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -Truncate $Truncate -Copy $Copy
 
         $script:lastOutput | Should -Be "copied output"
         Should -Invoke Copy-ToClipboard -Times 1 -Scope It -ParameterFilter { $Text -eq "copied output" }
@@ -6103,7 +6131,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -Truncate $Truncate -Copy $Copy
 
         $script:lastOutput | Should -Be "still output"
         Should -Invoke Copy-ToClipboard -Times 1 -Scope It
@@ -6148,7 +6176,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -Truncate $Truncate -Copy $Copy
 
         $script:lastOutput | Should -Be "No unresolved review threads found."
     }
@@ -6157,7 +6185,7 @@ Describe "Invoke-Main" {
         $Copy = [System.Management.Automation.SwitchParameter]::new($false)
         $CopyStrict = [System.Management.Automation.SwitchParameter]::new($true)
 
-        { Invoke-Main } | Should -Throw "*E_CONFIG_ERROR*-CopyStrict requires -Copy*"
+        { Invoke-Main -Copy:$Copy -CopyStrict:$CopyStrict } | Should -Throw "*E_CONFIG_ERROR*-CopyStrict requires -Copy*"
     }
 
     It "throws E_CLIPBOARD_COPY_FAILED when CopyStrict is set and copy fails" {
@@ -6205,7 +6233,7 @@ Describe "Invoke-Main" {
         Mock Format-UnresolvedThreadsAsText { "strict output" }
         Mock Copy-ToClipboard { $false }
 
-        { Invoke-Main } | Should -Throw "*E_CLIPBOARD_COPY_FAILED*"
+        { Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -Truncate $Truncate -Copy $Copy -CopyStrict $CopyStrict } | Should -Throw "*E_CLIPBOARD_COPY_FAILED*"
     }
 
     It "writes output file when OutputPath is provided and still writes stdout" {
@@ -6260,7 +6288,7 @@ Describe "Invoke-Main" {
             $script:lastOutput = $InputObject
         }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -OutputPath $OutputPath -Truncate $Truncate -Copy $Copy -CopyStrict $CopyStrict
 
         Should -Invoke Write-RenderedOutputToFile -Times 1 -Scope It -ParameterFilter { $OutputPath -eq (Join-Path -Path $TestDrive -ChildPath "artifacts/out.txt") -and $Text -eq "file output" }
         $script:lastOutput | Should -Be "file output"
@@ -6311,7 +6339,7 @@ Describe "Invoke-Main" {
         Mock Format-UnresolvedThreadsAsText { "ok" }
         Mock Write-Output { }
 
-        Invoke-Main
+        Invoke-TestMain $PullRequestUrl $Owner $Repo $GitHubHost $AllowedGitHubHosts $PullRequestNumber $Token $OutputFormat $Interactive $WaitOnRateLimit $PerPage $MaxPages $RequestTimeoutSeconds $OverallTimeoutSeconds -Truncate $Truncate -Copy $Copy
 
         Should -Invoke Get-UnresolvedReviewThreads -Times 1 -Scope It -ParameterFilter { $Truncate.IsPresent }
     }

--- a/Tests/Scoop/ScoopUpdate.Tests.ps1
+++ b/Tests/Scoop/ScoopUpdate.Tests.ps1
@@ -1,11 +1,11 @@
 BeforeAll {
     $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '../..')).Path
-    $scriptPath = Join-Path -Path $repoRoot -ChildPath 'Scripts/Scoop/ScoopUpdate.ps1'
+    $script:scriptPath = Join-Path -Path $repoRoot -ChildPath 'Scripts/Scoop/ScoopUpdate.ps1'
 }
 
 Describe 'Scoop update automation' {
     It 'runs the all-app update exactly once' {
-        $content = [System.IO.File]::ReadAllText($scriptPath, [System.Text.Encoding]::UTF8) -replace "`r", ''
+        $content = [System.IO.File]::ReadAllText($script:scriptPath, [System.Text.Encoding]::UTF8) -replace "`r", ''
 
         @([regex]::Matches($content, '(?m)^\s*scoop\s+update\s+\*\s*$')).Count | Should -Be 1
         $content | Should -Match '\$scoopExitCode\s*=\s*\$LASTEXITCODE'

--- a/Tests/Utils/CompatibilityConventions.Tests.ps1
+++ b/Tests/Utils/CompatibilityConventions.Tests.ps1
@@ -452,7 +452,6 @@ Describe "Cross-version compatibility - automatic variable scan (dependency-free
         # Mirrors the gate's AST scan but needs no PSScriptAnalyzer, so it runs on every
         # lane (including the Windows PowerShell 5.1 test lane). $IsWindows/$IsMacOS/$IsLinux
         # do not exist on Desktop edition and throw under StrictMode; $PSStyle is 7.2+.
-        $forbidden = @('IsWindows', 'IsMacOS', 'IsLinux', 'IsCoreCLR', 'PSStyle')
         $scanRoots = @('Scripts', 'Config', 'Tests') |
             ForEach-Object { Join-Path -Path $script:repoRoot -ChildPath $_ } |
             Where-Object { Test-Path -LiteralPath $_ -PathType Container }

--- a/Tests/Utils/CompatibilityHelpers.Tests.ps1
+++ b/Tests/Utils/CompatibilityHelpers.Tests.ps1
@@ -677,8 +677,7 @@ Describe "Get-PortableLinkTarget" {
         $item = Get-Item -LiteralPath $cycleA -Force
         # The visited-target set (plus the MaxDepth bound) must break the cycle rather than hang,
         # and return $null to match the native ResolveLinkTarget($true) "unresolved" outcome.
-        $cycleResult = $null
-        { $cycleResult = Get-PortableLinkTarget -Item $item -ForceFallback } | Should -Not -Throw
+        $cycleResult = Get-PortableLinkTarget -Item $item -ForceFallback
         $cycleResult | Should -BeNullOrEmpty -Because "a symbolic-link cycle is unresolvable, mirroring native ResolveLinkTarget."
     }
 }

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -948,7 +948,6 @@ Describe "Scope safety conventions" {
 
     It "gates the fast exit so it never strands an interactive or read-from terminal" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
-        $content = Get-Content -Path $fullPath -Raw
         $tokens = $null
         $parseErrors = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($fullPath, [ref]$tokens, [ref]$parseErrors)
@@ -1147,7 +1146,6 @@ Describe "Scope safety conventions" {
 
     It "prompts only through the canonical-mode terminal-read seam, never Read-Host" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
-        $content = Get-Content -Path $fullPath -Raw
         $tokens = $null
         $parseErrors = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($fullPath, [ref]$tokens, [ref]$parseErrors)
@@ -4062,7 +4060,6 @@ Describe "Backup script safety conventions" {
         # Scripts/Utils/Common/CanonicalJsonHelpers.ps1 so every writer shares one proven implementation.
         $helperPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/Common/CanonicalJsonHelpers.ps1"
         Test-Path -LiteralPath $helperPath | Should -BeTrue
-        $helperContent = (Get-Content -Path $helperPath -Raw) -replace "`r", ''
         $tokens = $null
         $parseErrors = $null
         $helperAst = [System.Management.Automation.Language.Parser]::ParseFile($helperPath, [ref]$tokens, [ref]$parseErrors)

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -942,12 +942,13 @@ Describe "Scope safety conventions" {
         # inside the existing dot-source guard so dot-sourced tests never terminate the host. The fast
         # exit is ALSO gated by Test-ShouldUseFastExit so a run that would strand the terminal (an
         # interactive host, or a run that read from the console) takes the safe managed exit instead.
-        $content | Should -Match 'Invoke-Main\s*\r?\n\s*#[\s\S]*?if\s*\(-not\s*\$NoFastExit\.IsPresent\s+-and\s+\(Test-ShouldUseFastExit\)\)\s*\{\s*\r?\n?\s*Invoke-FastProcessExit\s+-ExitCode\s+0'
+        $content | Should -Match 'Invoke-Main(?:\s+@[^\r\n]+)?\s*\r?\n\s*#[\s\S]*?if\s*\(-not\s*\$NoFastExit\.IsPresent\s+-and\s+\(Test-ShouldUseFastExit\)\)\s*\{\s*\r?\n?\s*Invoke-FastProcessExit\s+-ExitCode\s+0'
         $content | Should -Match 'if\s*\(-not\s*\$NoFastExit\.IsPresent\s+-and\s+\(Test-ShouldUseFastExit\)\)\s*\{\s*\r?\n?\s*Invoke-FastProcessExit\s+-ExitCode\s+1'
     }
 
     It "gates the fast exit so it never strands an interactive or read-from terminal" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1"
+        $content = Get-Content -Path $fullPath -Raw
         $tokens = $null
         $parseErrors = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($fullPath, [ref]$tokens, [ref]$parseErrors)

--- a/progress/session-017-test-fixture-remediation.md
+++ b/progress/session-017-test-fixture-remediation.md
@@ -1,0 +1,26 @@
+# Session 017: Test-fixture analyzer remediation
+
+Date: 2026-08-10
+
+## Scope
+
+Resolve the dynamic-scope PowerShell analyzer findings identified in issue #59 without excluding tests or weakening the production `Scripts/` warnings-as-errors lane.
+
+## Changes
+
+- Refactored `Invoke-Main` in `Scripts/Utils/GitHub/Get-UnresolvedPRComments.ps1` to accept its runtime inputs explicitly; the script entrypoint forwards the original bound parameter set.
+- Added an explicit test invocation helper and passed configured values from all `Invoke-Main` scenarios instead of relying on dynamic scope.
+- Removed a small set of genuine test-only unused locals and made the symbolic-link-cycle test assign its result outside a scriptblock so the analyzer can verify the use.
+
+## Verification
+
+- PSScriptAnalyzer 1.21.0 with `.psscriptanalyzer.psd1`: `Tests/` = 0 findings; production `Scripts/` = 0 findings.
+- `Get-UnresolvedPRComments.Tests.ps1` quality-gate suite passed.
+- `Tests/Utils` quality-gate suite passed.
+- Compatibility checks for the changed GitHub production/test scripts passed with zero findings.
+- Full validation preflight and `git diff --check` remain required before PR publication.
+
+## References
+
+- Issue [#43](https://github.com/wallstop/wallstop-utils/issues/43)
+- Follow-up issue [#59](https://github.com/wallstop/wallstop-utils/issues/59)


### PR DESCRIPTION
## Summary
- make `Invoke-Main` inputs explicit and remove dynamic-scope test setup
- eliminate the remaining PowerShell analyzer findings across `Tests/`
- update PLAN.md and record session-017 evidence

## Validation
- PSScriptAnalyzer 1.21.0 with `.psscriptanalyzer.psd1`: `Tests/` 0 findings; `Scripts/` 0 findings
- `Get-UnresolvedPRComments.Tests.ps1` quality-gate suite passed
- `Tests/Utils` quality-gate suite passed
- changed PowerShell compatibility checks passed with 0 findings
- `Invoke-FullValidation.ps1 -PreflightOnly` passed
- `git diff --check` passed

Closes #59. Issue #43 remains open for any analyzer scope outside the now-covered PowerShell, shell, native, and TypeScript lanes; issue #46 still requires a live Windows backup run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly test harness and explicit parameter wiring; production entry still forwards the same bound parameters, with validation noted in session-017.
> 
> **Overview**
> Closes the **issue #59** milestone by bringing **`Tests/`** to zero PSScriptAnalyzer findings without relaxing the production **`Scripts/`** warnings-as-errors lane.
> 
> **`Get-UnresolvedPRComments.ps1`:** `Invoke-Main` now declares the full CLI surface as parameters instead of reading script-scope variables; the real entrypoint still runs **`Invoke-Main @script:TopLevelBoundParameters`**, so runtime behavior stays aligned with bound script parameters (including optional-parameter detection via `TopLevelBoundParameters`).
> 
> **Tests:** Integration scenarios call a new **`Invoke-TestMain`** helper with explicit arguments rather than populating dynamic scope; a few small cleanups (unused locals, direct assignment outside scriptblocks, `$script:scriptPath` in Scoop tests) and a **ScriptSafetyConventions** regex tweak allow the fast-exit contract to match splatted **`Invoke-Main`**.
> 
> **Docs:** **PLAN.md** marks the Pester-fixture analyzer task done and links **session-017** evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cadde70d2894e4373862a4f424063b95c2f7291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->