### PR TITLE
Record completed analyzer surface inventory

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@
 ## Follow-up
 
 - Issue #46 (partial git uploads) now has explicit post-push remote-head verification and commit wording that distinguishes failed backup steps from Git publication. A live backup run remains required to close the operational investigation safely.
-- Issue #43 (warnings-as-errors and static-analyzer research) remains open for broader analyzer inventory and additional lanes; the managed production and test PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, 015, and 017.
+- Issue #43 (warnings-as-errors and static-analyzer research) is complete for the repository's supported managed quality surface: all tracked PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, 015, and 017. Remaining small-language analyzer decisions are tracked in follow-up issue #62.
 
 ## Next milestone: analyzer baseline for #43
 

--- a/progress/session-018-analyzer-surface-inventory.md
+++ b/progress/session-018-analyzer-surface-inventory.md
@@ -1,0 +1,31 @@
+# Session 018: Analyzer surface inventory
+
+Date: 2026-08-10
+
+## Scope
+
+Audit issue #43 after the test-fixture remediation and identify any remaining language surfaces that need a separate analyzer decision.
+
+## Verified managed coverage
+
+- 101 tracked PowerShell files: PSScriptAnalyzer 1.21.0 with `.psscriptanalyzer.psd1`, `Scripts/` and `Tests/` each at zero findings; changed files also pass the cross-version compatibility gate.
+- Managed shell targets: pinned ShellCheck/shfmt enforcement through the shared quality wrappers.
+- Lua: pinned StyLua enforcement for `Config/Wezterm/wezterm.lua`.
+- GitHub Actions: pinned actionlint enforcement for tracked workflow files.
+- TypeScript: extension `tsc` lane with `noUnusedLocals` and `noUnusedParameters` enabled and regression-tested.
+- AutoHotkey/batch: dedicated Windows-language static/runtime validation with v2 directive policy checks.
+- AppleScript: dedicated macOS migration-safe compile/decompile validation.
+
+## Remaining decision surface
+
+The repository has three tracked JavaScript utility scripts and four AppleScript files. JavaScript utilities are covered by the extension/package test workflow but do not have a dedicated ESLint lane; AppleScript has platform validation but no separate third-party linter. Follow-up issue [#62](https://github.com/wallstop/wallstop-utils/issues/62) captures the bounded evaluation without weakening fast-lane timing.
+
+## Decision
+
+Close the staged warnings-as-errors milestone for the managed surface in issue #43. Keep the small-language analyzer evaluation separate and explicit in #62.
+
+## Evidence
+
+- [PR #57](https://github.com/wallstop/wallstop-utils/pull/57)
+- [PR #58](https://github.com/wallstop/wallstop-utils/pull/58)
+- [PR #61](https://github.com/wallstop/wallstop-utils/pull/61)


### PR DESCRIPTION
## Summary
- record the completed managed analyzer coverage audit for issue #43
- document the bounded JavaScript and AppleScript follow-up in issue #62
- update PLAN evidence and milestone state

## Validation
- `git diff --check`
- repository quality evidence recorded in `progress/session-018-analyzer-surface-inventory.md`

Closes #43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning updates only; no runtime, CI, or analyzer behavior changes.
> 
> **Overview**
> **Closes the issue #43 warnings-as-errors milestone** in planning docs and adds session **018** evidence for the post–test-fixture audit.
> 
> `PLAN.md` now states that deterministic enforcement is **complete** for the managed lanes (PowerShell, ShellCheck/shfmt, StyLua, actionlint, TypeScript) and defers **JavaScript ESLint** and **AppleScript third-party linter** decisions to **#62**, instead of describing #43 as still open for broader inventory work.
> 
> `progress/session-018-analyzer-surface-inventory.md` records verified lane coverage, the bounded remaining surface (three JS utilities, four AppleScript files), the decision to close #43 for the managed surface, and links to PRs **#57**, **#58**, and **#61**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043f3b620f731b5eb4b5f63a4458ffb8790769e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->