### PR TITLE
Clarify PowerShell analyzer scope

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@
 ## Follow-up
 
 - Issue #46 (partial git uploads) now has explicit post-push remote-head verification and commit wording that distinguishes failed backup steps from Git publication. A live backup run remains required to close the operational investigation safely.
-- Issue #43 (warnings-as-errors and static-analyzer research) is complete for the repository's supported managed quality surface: all tracked PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, 015, and 017. Remaining small-language analyzer decisions are tracked in follow-up issue #62.
+- Issue #43 (warnings-as-errors and static-analyzer research) is complete for the repository's supported managed quality surface: tracked production and test PowerShell, ShellCheck/shfmt, StyLua, actionlint, and TypeScript compiler lanes now have deterministic enforcement documented in sessions 004–007, 013, 015, and 017. Intentional PowerShell profile files under `Config/Powershell/` remain outside the managed script lane; remaining small-language analyzer decisions are tracked in follow-up issue #62.
 
 ## Next milestone: analyzer baseline for #43
 

--- a/progress/session-018-analyzer-surface-inventory.md
+++ b/progress/session-018-analyzer-surface-inventory.md
@@ -8,7 +8,7 @@ Audit issue #43 after the test-fixture remediation and identify any remaining la
 
 ## Verified managed coverage
 
-- 101 tracked PowerShell files: PSScriptAnalyzer 1.21.0 with `.psscriptanalyzer.psd1`, `Scripts/` and `Tests/` each at zero findings; changed files also pass the cross-version compatibility gate.
+- 101 tracked PowerShell files: PSScriptAnalyzer 1.21.0 with `.psscriptanalyzer.psd1`; the managed `Scripts/` and `Tests/` lanes each have zero findings and changed files pass the cross-version compatibility gate. Four intentional `Config/Powershell/` profile files retain `PSAvoidUsingCmdletAliases` warnings and are outside that managed script lane.
 - Managed shell targets: pinned ShellCheck/shfmt enforcement through the shared quality wrappers.
 - Lua: pinned StyLua enforcement for `Config/Wezterm/wezterm.lua`.
 - GitHub Actions: pinned actionlint enforcement for tracked workflow files.


### PR DESCRIPTION
## Summary
- distinguish managed `Scripts/` and `Tests/` analyzer lanes from intentional `Config/Powershell/` profiles
- align PLAN.md and session-018 evidence with the observed four profile warnings

## Validation
- full PR quality gates ran on the preceding documentation change
- final local audit confirms 101 tracked PowerShell files and four intentional profile warnings

Follow-up to #63

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only PLAN.md and session notes change; no scripts, hooks, or analyzer configuration are modified.
> 
> **Overview**
> Documentation-only alignment for issue **#43**: the **managed** PSScriptAnalyzer surface is **`Scripts/`** and **`Tests/`** (zero findings), not every tracked `.ps1`.
> 
> **`PLAN.md`** now says warnings-as-errors completion applies to tracked **production and test** PowerShell, and calls out that four intentional **`Config/Powershell/`** profile files stay **outside** the managed script lane (with **`PSAvoidUsingCmdletAliases`** warnings still allowed).
> 
> **`progress/session-018-analyzer-surface-inventory.md`** splits the same story: managed lanes vs the four profile files, without changing enforcement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d1f7d21997c57ded4e391c15a47bd7f72657aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->