### PR TITLE
Restore Komorebi monitor layouts

### DIFF
--- a/Config/Komorebi/profiles/default/komorebi.json
+++ b/Config/Komorebi/profiles/default/komorebi.json
@@ -3,9 +3,11 @@
   "app_specific_configuration_path": "$Env:USERPROFILE/applications.json",
   "window_hiding_behaviour": "Cloak",
   "cross_monitor_move_behaviour": "Insert",
-  "default_workspace_padding": 0,
-  "default_container_padding": 0,
+  "default_workspace_padding": 2,
+  "default_container_padding": 2,
   "border": false,
+  "border_width": 2,
+  "border_offset": 0,
   "mouse_follows_focus": true,
   "animation": {
     "enabled": false,
@@ -26,21 +28,29 @@
     {
       "workspaces": [
         {
-          "name": "I",
-          "layout": "Scrolling",
-          "layout_options": {
-            "scrolling": {
-              "columns": 1,
-              "center_focused_column": true
-            }
-          },
-          "workspace_padding": 0,
-          "container_padding": 0
+          "name": "Middle",
+          "layout": "Grid"
+        }
+      ]
+    },
+    {
+      "workspaces": [
+        {
+          "name": "Right",
+          "layout": "Rows"
+        }
+      ]
+    },
+    {
+      "workspaces": [
+        {
+          "name": "Left",
+          "layout": "Rows"
         }
       ]
     }
   ],
-  "float_rules": [
+  "ignore_rules": [
     {
       "kind": "Title",
       "id": " Hot Reload",

--- a/progress/session-001-komorebi-layout-restore.md
+++ b/progress/session-001-komorebi-layout-restore.md
@@ -1,0 +1,6 @@
+# Komorebi layout restoration
+
+- Audited the wallstop-utils history and confirmed the long-lived three-monitor layout: center Grid, side Rows.
+- Restored the profile configuration for current Komorebi v0.1.41 while retaining JSON application rules.
+- Validated the profile and live configuration, restarted Komorebi with a clean state, and verified monitor layouts.
+- Published the change through a draft pull request after repository validation.


### PR DESCRIPTION
## Summary

- Restore the canonical three-monitor Komorebi layout: center `Grid`, right `Rows`, and left `Rows` based on the current display geometry.
- Restore the historical 2px workspace/container padding and border metadata.
- Modernize deprecated `float_rules` to `ignore_rules` for Komorebi v0.1.41 while preserving all rules.
- Add the required session progress log.

## Root cause

The migrated default profile had collapsed to one `Scrolling` workspace with zero padding, losing the long-lived three-monitor layout present in the repository history. The YAML history was for application rules; the current JSON application configuration remains in use.

## Validation

- `komorebic check --komorebi-config` passed for both live and profile configs.
- Live Komorebi restarted with `--clean-state` and reported `Middle/Grid`, `Right/Rows`, and `Left/Rows`.
- Canonical JSON and Komorebi profile-helper tests passed.
- Profile-scoped pre-commit hooks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local window-manager JSON and documentation only; no application code, auth, or data paths.
> 
> **Overview**
> Restores the **default Komorebi profile** from a single **Scrolling** workspace with **0px** padding to the historical **three-monitor** setup: **Middle/Grid**, **Right/Rows**, and **Left/Rows**, with **2px** default workspace and container padding and explicit **border_width** / **border_offset** metadata.
> 
> Renames **`float_rules`** to **`ignore_rules`** for Komorebi **v0.1.41** while keeping the same title-matching entries. Adds a short **session progress** note documenting the audit, restore, and validation steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81dd391fba07fd24fbebcef5a621ddfe9ebd572f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->