### PR TITLE
Diagnose partial backup uploads: name failing steps, stop daily scoopfile.json churn

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -62,6 +62,7 @@ All front-end wrapper files must point here and should not duplicate policy text
 7. Prefer category-level guidance over brittle one-off rules.
 8. Keep commits bisectable: each commit must pass all gates independently.
 9. **Mandatory post-work self-improvement**: after any significant work, execute the [post-work self-improvement workflow](./skills/post-work-self-improvement.md) using sub-agents with adversarial consensus to analyze work done, extract new knowledge, and update `.llm/` guidance. This is a session-close gate, not optional. See [expanded guide](./skill-details/post-work-self-improvement.md) for trigger criteria and protocol.
+10. Start multi-unit work on its feature branch before the first commit; recover wrong-base commits by branching at the commit, and never run history-destroying recovery (`git reset --hard`) while unstaged unit changes are pending — stage or stash them first.
 
 ## Primary Commands
 
@@ -183,6 +184,8 @@ array semantics in empty-result paths.
 - Use `return , @()` (comma operator) when callers access `.Count` directly on the result.
 - If callers always wrap with `@()`, the bare `return @()` is safe — add `# array-unwrap-safe`.
 - Do not comma-wrap already materialized arrays returned to call sites that already use `@(...)`; `return , $array` in that case creates nested arrays and breaks `foreach` step iteration.
+- Unrolling also hits non-empty `IEnumerable` containers returned bare from functions (`List[T]`, `HashSet[T]`, `System.Text.Json.Nodes.JsonObject`/`JsonArray`; non-generic `IDictionary` types like hashtable travel whole), so callers get element sequences instead of the container and downstream `.Add` calls then fail overload resolution.
+- When callers need container identity, comma-wrap the return (`return , $container`; precedent: `ConvertTo-JsonNodeWithSortedObjectKeys` in `Scripts/Utils/Common/CanonicalJsonHelpers.ps1`).
 - For array-return helpers with multiple call sites, keep one explicit contract end-to-end: either bare returns + `@(...)` at every call site, or comma-wrapped returns + non-wrapped call sites; do not mix contracts.
 - Add both behavioral and structural coverage for high-risk array-return helpers: behavior tests for empty/non-empty flattening plus AST/pattern checks that call-site wrapper usage matches the helper's return contract.
 - A convention test in `ScriptSafetyConventions.Tests.ps1` enforces this in `Scripts/`.

--- a/.llm/skill-details/config-snapshot-safety.md
+++ b/.llm/skill-details/config-snapshot-safety.md
@@ -20,6 +20,18 @@ Run focused checks before widening any validator include patterns.
 
 Backup orchestration should stage only managed snapshot outputs under `Config/`; any out-of-scope mutations must fail fast rather than being auto-committed.
 
+## Generator Nondeterminism And Whole-File Churn
+
+When a managed snapshot shows whole-file diffs while the underlying data is unchanged,
+suspect upstream generator nondeterminism (member/key order), not data drift: some
+generators build output from unordered structures so member order varies per invocation
+(example: `scoop export` builds each app object from a PowerShell hashtable). Normalize
+at the writer rather than hand-sorting committed artifacts: route through
+`ConvertTo-CanonicalJsonText -SortObjectKeys` (`Scripts/Utils/Common/CanonicalJsonHelpers.ps1`),
+which rebuilds object members in Ordinal key order recursively while staying a
+byte-identical fixed point of the `pretty-format-json --no-sort-keys` hook. Formatter
+hooks stay order-preserving (`--no-sort-keys`); sorting happens only at the source.
+
 ## References
 
 - `.pre-commit-config.yaml`

--- a/.llm/skill-details/github-api-auth-vscode-connector.md
+++ b/.llm/skill-details/github-api-auth-vscode-connector.md
@@ -1,0 +1,80 @@
+# GitHub API Auth Via VSCode Connector (Expanded)
+
+This expanded guide supports the lightweight skill stub in
+`.llm/skills/github-api-auth-vscode-connector/SKILL.md`.
+
+## Etiquette (user directive, binding)
+
+- **Check first**: probe cached/ambient credentials (existing store files, `GH_TOKEN`/`GITHUB_TOKEN`,
+  anonymous public-API reads) before any credential acquisition.
+- **Prompt and cache**: if unauthenticated, acquire credentials at most ONCE, then cache them for the
+  session (mode-600 file outside the repository).
+- **Never repeatedly prompt**: repeated failed acquisition attempts surface as interactive prompts in
+  the user's VSCode window. Two bounded failures on a channel means fall through to the next channel,
+  not retry.
+
+## Channel Priority
+
+1. VSCode connector/extension (git askpass chain).
+2. git over SSH (push/pull; no API mutations).
+3. gh CLI — NOT installed in this devcontainer image.
+4. Fallback: install https://github.com/github/mcp-server as an opencode MCP server.
+
+`gh` absence is not a blocker: once a token exists, `curl` with an `Authorization: Bearer <token>`
+header performs every API mutation (PR create/update, issue comment, check polling).
+
+## The Working Recipe (VSCode Connector)
+
+VSCode injects `GIT_ASKPASS`, `VSCODE_GIT_ASKPASS_NODE`, `VSCODE_GIT_ASKPASS_MAIN`,
+`VSCODE_GIT_IPC_HANDLE`. The askpass answers git's HTTPS prompts from the user's GitHub session.
+
+Do NOT invoke `askpass-main.js` directly: without `VSCODE_GIT_ASKPASS_PIPE` and
+`VSCODE_GIT_ASKPASS_TYPE=https` it exits with "Missing or invalid credentials. / Missing pipe", which
+is an invocation error, not proof that auth is missing. `git credential fill` against this helper also
+hangs when the UI does not answer that channel; treat empty output as fall-through, never as a retry
+signal.
+
+Sanctioned capture-and-cache: let git drive ONE real HTTPS operation with an isolated store helper so
+the askpass-supplied token lands in a session-local file:
+
+```bash
+rm -f /tmp/opencode/git-cred-store && touch /tmp/opencode/git-cred-store && chmod 600 /tmp/opencode/git-cred-store
+GIT_TERMINAL_PROMPT=0 timeout 60 \
+  git -c credential.helper= \
+      -c "credential.helper=store --file=/tmp/opencode/git-cred-store" \
+      push --dry-run https://github.com/<owner>/<repo>.git HEAD:refs/heads/<probe-ref>
+# --dry-run mutates nothing; the auth challenge still completes and gets stored.
+```
+
+Then extract and validate WITHOUT echoing secrets:
+
+```bash
+TOKEN=$(sed -E 's#^https://[^:]+:([^@]+)@github.com$#\1#' /tmp/opencode/git-cred-store)
+curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" https://api.github.com/user
+```
+
+Rules:
+
+- Store files live under `/tmp/opencode/` (never inside the repository), mode 600, deleted when done.
+- Never print tokens, embed them in command output, logs, commit messages, or `.llm/` files.
+- Validate with `GET /user` before any mutating call.
+- Anonymous GETs on public repositories (issues, PRs, checks) need no token; use them for read-only
+  triage so no prompt ever occurs for pure inspection.
+
+## Pull Requests Without gh
+
+```bash
+jq -Rs '{title: $t, head: $h, base: "main", body: .}' body.md > payload.json   # with --arg t/--arg h
+POST /repos/{owner}/{repo}/pulls  -> 201 returns number + html_url
+```
+
+Poll PR checks anonymously or authenticated via `/repos/{owner}/{repo}/commits/<sha>/check-runs`;
+address failures before handoff (GOAL.md green-state requirement).
+
+## Diagnostics Quick Reference
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| "Missing pipe" from askpass-main.js | Direct invocation missing env contract | Use the git-driven recipe above |
+| `git credential fill` hangs/empty | UI did not answer that channel | Fall through channel order once |
+| HTTP 401 Bad credentials | Cached token stale/revoked | Re-acquire ONCE via recipe, re-cache |

--- a/.llm/skills-index.md
+++ b/.llm/skills-index.md
@@ -38,6 +38,7 @@ This file is generated. Do not edit generated sections manually.
 
 | Skill Card | Expanded Guide | Trigger Keywords | Usage |
 | --- | --- | --- | --- |
+| [GitHub API Auth Vscode Connector](./skills/github-api-auth-vscode-connector/SKILL.md) | [Expanded Guide](./skill-details/github-api-auth-vscode-connector.md) | github api auth, vscode askpass, credential helper, bearer token, gh cli fallback, github mcp server, pull request creation, single prompt, cache credentials | Obtain and use GitHub API credentials inside this devcontainer via the VSCode git askpass connector chain, with check-first, single-prompt-and-cache etiquette. |
 | [GitHub PR Unresolved Comments](./skills/github-pr-unresolved-comments/SKILL.md) | [Expanded Guide](./skill-details/github-pr-unresolved-comments.md) | github api, unresolved comments, github copilot, copilot-pull-request-reviewer, cursor bugbot, suggested changes, retries, auth recovery, GH_TOKEN, GITHUB_TOKEN, output encoding | Safely inspect and render unresolved GitHub pull-request comments, suggested changes, bot feedback, and resilient API output. |
 
 <!-- END GENERATED SKILLS INDEX -->

--- a/.llm/skills/github-api-auth-vscode-connector/SKILL.md
+++ b/.llm/skills/github-api-auth-vscode-connector/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: github-api-auth-vscode-connector
+description: Obtain and use GitHub API credentials inside this devcontainer via the VSCode git askpass connector chain, with check-first, single-prompt-and-cache etiquette.
+metadata:
+  category: GitHub
+  keywords: github api auth, vscode askpass, credential helper, bearer token, gh cli fallback, github mcp server, pull request creation, single prompt, cache credentials
+  details: ../../skill-details/github-api-auth-vscode-connector.md
+---
+
+# GitHub API Auth Via VSCode Connector
+
+Follow the expanded repository guide:
+[GitHub API Auth Via VSCode Connector](../../skill-details/github-api-auth-vscode-connector.md).
+
+Channel priority for GitHub operations: VSCode connector/extension first, then git, then gh
+(install https://github.com/github/github-mcp-server as an MCP server only if those fail).

--- a/Config/scoopfile.json
+++ b/Config/scoopfile.json
@@ -4,677 +4,677 @@
       "Info": "",
       "Name": "7zip",
       "Source": "main",
-      "Version": "26.02",
-      "Updated": "2026-06-26T23:30:15.462921-07:00"
+      "Updated": "2026-06-26T23:30:15.462921-07:00",
+      "Version": "26.02"
     },
     {
       "Info": "",
       "Name": "audacity",
       "Source": "extras",
-      "Version": "3.7.8",
-      "Updated": "2026-08-10T16:19:13.1656331-07:00"
+      "Updated": "2026-08-10T16:19:13.1656331-07:00",
+      "Version": "3.7.8"
     },
     {
       "Info": "",
       "Name": "audioswitcher",
       "Source": "extras",
-      "Version": "1.8.0.142",
-      "Updated": "2025-05-20T10:18:26.1326218-07:00"
+      "Updated": "2025-05-20T10:18:26.1326218-07:00",
+      "Version": "1.8.0.142"
     },
     {
       "Info": "",
       "Name": "autohotkey",
       "Source": "extras",
-      "Version": "2.0.26",
-      "Updated": "2026-05-05T09:36:06.1879167-07:00"
+      "Updated": "2026-05-05T09:36:06.1879167-07:00",
+      "Version": "2.0.26"
     },
     {
       "Info": "",
       "Name": "autologon",
       "Source": "sysinternals",
-      "Version": "3.10",
-      "Updated": "2026-05-05T09:37:40.9631402-07:00"
+      "Updated": "2026-05-05T09:37:40.9631402-07:00",
+      "Version": "3.10"
     },
     {
       "Info": "",
       "Name": "aws",
       "Source": "main",
-      "Version": "2.36.29",
-      "Updated": "2026-08-21T23:30:40.4009344-07:00"
+      "Updated": "2026-08-21T23:30:40.4009344-07:00",
+      "Version": "2.36.29"
     },
     {
       "Info": "",
       "Name": "base64",
       "Source": "main",
-      "Version": "1.3.1",
-      "Updated": "2025-10-05T23:30:15.7642611-07:00"
+      "Updated": "2025-10-05T23:30:15.7642611-07:00",
+      "Version": "1.3.1"
     },
     {
       "Info": "",
       "Name": "bazel",
       "Source": "main",
-      "Version": "9.2.0",
-      "Updated": "2026-07-13T23:30:45.5171633-07:00"
+      "Updated": "2026-07-13T23:30:45.5171633-07:00",
+      "Version": "9.2.0"
     },
     {
       "Info": "",
       "Name": "bazel-buildtools",
       "Source": "main",
-      "Version": "8.5.1",
-      "Updated": "2026-05-14T16:41:43.0977328-07:00"
+      "Updated": "2026-05-14T16:41:43.0977328-07:00",
+      "Version": "8.5.1"
     },
     {
       "Info": "",
       "Name": "bun",
       "Source": "main",
-      "Version": "1.4.0",
-      "Updated": "2026-08-20T23:30:54.6070905-07:00"
+      "Updated": "2026-08-20T23:30:54.6070905-07:00",
+      "Version": "1.4.0"
     },
     {
       "Info": "",
       "Name": "busybox",
       "Source": "main",
-      "Version": "6075-g169694ebd",
-      "Updated": "2026-05-14T16:41:46.9867375-07:00"
+      "Updated": "2026-05-14T16:41:46.9867375-07:00",
+      "Version": "6075-g169694ebd"
     },
     {
       "Info": "",
       "Name": "cacert",
       "Source": "main",
-      "Version": "2026-08-13",
-      "Updated": "2026-08-12T23:30:54.1822015-07:00"
+      "Updated": "2026-08-12T23:30:54.1822015-07:00",
+      "Version": "2026-08-13"
     },
     {
       "Info": "",
       "Name": "calibre",
       "Source": "extras",
-      "Version": "9.13.0",
-      "Updated": "2026-08-09T20:01:26.1335397-07:00"
+      "Updated": "2026-08-09T20:01:26.1335397-07:00",
+      "Version": "9.13.0"
     },
     {
       "Info": "",
       "Name": "carnac",
       "Source": "extras",
-      "Version": "2.3.13",
-      "Updated": "2026-01-24T08:27:30.9136598-08:00"
+      "Updated": "2026-01-24T08:27:30.9136598-08:00",
+      "Version": "2.3.13"
     },
     {
       "Info": "",
       "Name": "chatgpt",
       "Source": "extras",
-      "Version": "1.1.0",
-      "Updated": "2025-05-20T10:02:19.3464179-07:00"
+      "Updated": "2025-05-20T10:02:19.3464179-07:00",
+      "Version": "1.1.0"
     },
     {
       "Info": "",
       "Name": "cmake",
       "Source": "main",
-      "Version": "4.4.2",
-      "Updated": "2026-08-05T18:45:51.5727498-07:00"
+      "Updated": "2026-08-05T18:45:51.5727498-07:00",
+      "Version": "4.4.2"
     },
     {
       "Info": "",
       "Name": "curl",
       "Source": "main",
-      "Version": "8.21.0_7",
-      "Updated": "2026-08-13T23:30:58.7477844-07:00"
+      "Updated": "2026-08-13T23:30:58.7477844-07:00",
+      "Version": "8.21.0_7"
     },
     {
       "Info": "",
       "Name": "cursor",
       "Source": "extras",
-      "Version": "3.17.8",
-      "Updated": "2026-08-20T23:32:52.6378638-07:00"
+      "Updated": "2026-08-20T23:32:52.6378638-07:00",
+      "Version": "3.17.8"
     },
     {
       "Info": "",
       "Name": "dark",
       "Source": "main",
-      "Version": "3.14.1",
-      "Updated": "2025-05-20T10:15:49.4024887-07:00"
+      "Updated": "2025-05-20T10:15:49.4024887-07:00",
+      "Version": "3.14.1"
     },
     {
       "Info": "",
       "Name": "deluge",
       "Source": "extras",
-      "Version": "2.2.0",
-      "Updated": "2025-05-20T11:12:29.0039929-07:00"
+      "Updated": "2025-05-20T11:12:29.0039929-07:00",
+      "Version": "2.2.0"
     },
     {
       "Info": "",
       "Name": "deno",
       "Source": "main",
-      "Version": "2.9.5",
-      "Updated": "2026-08-09T20:02:06.7360085-07:00"
+      "Updated": "2026-08-09T20:02:06.7360085-07:00",
+      "Version": "2.9.5"
     },
     {
       "Info": "",
       "Name": "everything",
       "Source": "extras",
-      "Version": "1.4.1.1032",
-      "Updated": "2026-02-23T11:20:54.933526-08:00"
+      "Updated": "2026-02-23T11:20:54.933526-08:00",
+      "Version": "1.4.1.1032"
     },
     {
       "Info": "",
       "Name": "fancontrol",
       "Source": "extras",
-      "Version": "273",
-      "Updated": "2026-08-12T23:32:36.1811756-07:00"
+      "Updated": "2026-08-12T23:32:36.1811756-07:00",
+      "Version": "273"
     },
     {
       "Info": "",
       "Name": "ffmpeg",
       "Source": "main",
-      "Version": "9.0.1",
-      "Updated": "2026-08-12T23:32:47.1187825-07:00"
+      "Updated": "2026-08-12T23:32:47.1187825-07:00",
+      "Version": "9.0.1"
     },
     {
       "Info": "",
       "Name": "flow-launcher",
       "Source": "extras",
-      "Version": "2.1.3",
-      "Updated": "2026-06-08T12:52:27.2398654-07:00"
+      "Updated": "2026-06-08T12:52:27.2398654-07:00",
+      "Version": "2.1.3"
     },
     {
       "Info": "",
       "Name": "foobar2000",
       "Source": "extras",
-      "Version": "2.25.10",
-      "Updated": "2026-06-26T23:31:55.0127396-07:00"
+      "Updated": "2026-06-26T23:31:55.0127396-07:00",
+      "Version": "2.25.10"
     },
     {
       "Info": "",
       "Name": "freac",
       "Source": "extras",
-      "Version": "1.1.7",
-      "Updated": "2025-07-15T09:17:12.7701919-07:00"
+      "Updated": "2025-07-15T09:17:12.7701919-07:00",
+      "Version": "1.1.7"
     },
     {
       "Info": "",
       "Name": "gcc",
       "Source": "main",
-      "Version": "15.2.0",
-      "Updated": "2026-01-01T23:30:44.8955254-08:00"
+      "Updated": "2026-01-01T23:30:44.8955254-08:00",
+      "Version": "15.2.0"
     },
     {
       "Info": "",
       "Name": "gh",
       "Source": "main",
-      "Version": "2.98.0",
-      "Updated": "2026-08-20T23:32:55.1520714-07:00"
+      "Updated": "2026-08-20T23:32:55.1520714-07:00",
+      "Version": "2.98.0"
     },
     {
       "Info": "",
       "Name": "ghostscript",
       "Source": "main",
-      "Version": "10.07.1",
-      "Updated": "2026-05-27T16:04:39.4747393-07:00"
+      "Updated": "2026-05-27T16:04:39.4747393-07:00",
+      "Version": "10.07.1"
     },
     {
       "Info": "",
       "Name": "github",
       "Source": "extras",
-      "Version": "3.6.4",
-      "Updated": "2026-08-13T23:31:17.0412655-07:00"
+      "Updated": "2026-08-13T23:31:17.0412655-07:00",
+      "Version": "3.6.4"
     },
     {
       "Info": "",
       "Name": "go",
       "Source": "main",
-      "Version": "1.27.0",
-      "Updated": "2026-08-19T23:32:54.0001055-07:00"
+      "Updated": "2026-08-19T23:32:54.0001055-07:00",
+      "Version": "1.27.0"
     },
     {
       "Info": "Held package",
       "Name": "godot",
       "Source": "extras",
-      "Version": "4.7.1",
-      "Updated": "2026-08-12T19:47:00.7240678-07:00"
+      "Updated": "2026-08-12T19:47:00.7240678-07:00",
+      "Version": "4.7.1"
     },
     {
       "Info": "",
       "Name": "googlechrome",
       "Source": "extras",
-      "Version": "151.0.7922.174",
-      "Updated": "2026-08-20T23:33:05.3375116-07:00"
+      "Updated": "2026-08-20T23:33:05.3375116-07:00",
+      "Version": "151.0.7922.174"
     },
     {
       "Info": "",
       "Name": "graalvm22-jdk17",
       "Source": "java",
-      "Version": "22.3.3",
-      "Updated": "2026-07-04T23:30:31.1199914-07:00"
+      "Updated": "2026-07-04T23:30:31.1199914-07:00",
+      "Version": "22.3.3"
     },
     {
       "Info": "",
       "Name": "gradle",
       "Source": "main",
-      "Version": "9.7.1",
-      "Updated": "2026-08-19T23:34:50.8449616-07:00"
+      "Updated": "2026-08-19T23:34:50.8449616-07:00",
+      "Version": "9.7.1"
     },
     {
       "Info": "",
       "Name": "gzip",
       "Source": "main",
-      "Version": "1.3.12",
-      "Updated": "2025-08-02T16:25:20.7960191-07:00"
+      "Updated": "2025-08-02T16:25:20.7960191-07:00",
+      "Version": "1.3.12"
     },
     {
       "Info": "",
       "Name": "httrack",
       "Source": "extras",
-      "Version": "3.49.2",
-      "Updated": "2025-06-09T17:44:52.9519505-07:00"
+      "Updated": "2025-06-09T17:44:52.9519505-07:00",
+      "Version": "3.49.2"
     },
     {
       "Info": "",
       "Name": "imageglass",
       "Source": "extras",
-      "Version": "9.6.1.807",
-      "Updated": "2026-08-09T20:03:30.430492-07:00"
+      "Updated": "2026-08-09T20:03:30.430492-07:00",
+      "Version": "9.6.1.807"
     },
     {
       "Info": "",
       "Name": "innounp",
       "Source": "main",
-      "Version": "2025",
-      "Updated": "2025-11-06T23:30:59.3532-08:00"
+      "Updated": "2025-11-06T23:30:59.3532-08:00",
+      "Version": "2025"
     },
     {
       "Info": "",
       "Name": "just",
       "Source": "main",
-      "Version": "1.58.0",
-      "Updated": "2026-08-05T18:46:17.3429249-07:00"
+      "Updated": "2026-08-05T18:46:17.3429249-07:00",
+      "Version": "1.58.0"
     },
     {
       "Info": "",
       "Name": "keyviz",
       "Source": "extras",
-      "Version": "2.1.1",
-      "Updated": "2026-08-09T20:03:32.360281-07:00"
+      "Updated": "2026-08-09T20:03:32.360281-07:00",
+      "Version": "2.1.1"
     },
     {
       "Info": "",
       "Name": "komorebi",
       "Source": "extras",
-      "Version": "0.1.41",
-      "Updated": "2026-05-05T09:36:50.512953-07:00"
+      "Updated": "2026-05-05T09:36:50.512953-07:00",
+      "Version": "0.1.41"
     },
     {
       "Info": "",
       "Name": "lazygit",
       "Source": "extras",
-      "Version": "0.63.1",
-      "Updated": "2026-07-15T10:02:19.6621991-07:00"
+      "Updated": "2026-07-15T10:02:19.6621991-07:00",
+      "Version": "0.63.1"
     },
     {
       "Info": "",
       "Name": "libreoffice",
       "Source": "extras",
-      "Version": "26.2.5",
-      "Updated": "2026-07-30T20:28:23.7949499-07:00"
+      "Updated": "2026-07-30T20:28:23.7949499-07:00",
+      "Version": "26.2.5"
     },
     {
       "Info": "",
       "Name": "linqpad",
       "Source": "extras",
-      "Version": "9.10.19",
-      "Updated": "2026-08-12T23:32:50.5926952-07:00"
+      "Updated": "2026-08-12T23:32:50.5926952-07:00",
+      "Version": "9.10.19"
     },
     {
       "Info": "",
       "Name": "llvm",
       "Source": "main",
-      "Version": "22.1.8",
-      "Updated": "2026-06-17T23:33:10.2844864-07:00"
+      "Updated": "2026-06-17T23:33:10.2844864-07:00",
+      "Version": "22.1.8"
     },
     {
       "Info": "",
       "Name": "lychee",
       "Source": "main",
-      "Version": "0.24.2",
-      "Updated": "2026-05-14T16:44:36.5770614-07:00"
+      "Updated": "2026-05-14T16:44:36.5770614-07:00",
+      "Version": "0.24.2"
     },
     {
       "Info": "",
       "Name": "make",
       "Source": "main",
-      "Version": "4.4.1",
-      "Updated": "2025-09-21T18:17:03.7767054-07:00"
+      "Updated": "2025-09-21T18:17:03.7767054-07:00",
+      "Version": "4.4.1"
     },
     {
       "Info": "",
       "Name": "megacmd",
       "Source": "main",
-      "Version": "2.5.2",
-      "Updated": "2026-04-19T11:41:17.766084-07:00"
+      "Updated": "2026-04-19T11:41:17.766084-07:00",
+      "Version": "2.5.2"
     },
     {
       "Info": "Install failed",
       "Name": "megatools",
       "Source": null,
-      "Version": null,
-      "Updated": "2025-12-27T21:56:30.9168446-08:00"
+      "Updated": "2025-12-27T21:56:30.9168446-08:00",
+      "Version": null
     },
     {
       "Info": "",
       "Name": "mise",
       "Source": "main",
-      "Version": "2026.8.10",
-      "Updated": "2026-08-20T23:33:08.5619665-07:00"
+      "Updated": "2026-08-20T23:33:08.5619665-07:00",
+      "Version": "2026.8.10"
     },
     {
       "Info": "",
       "Name": "mobaxterm",
       "Source": "extras",
-      "Version": "26.4",
-      "Updated": "2026-06-19T23:31:35.4642197-07:00"
+      "Updated": "2026-06-19T23:31:35.4642197-07:00",
+      "Version": "26.4"
     },
     {
       "Info": "",
       "Name": "mp3tag",
       "Source": "extras",
-      "Version": "3.35.1",
-      "Updated": "2026-07-01T23:31:00.9526221-07:00"
+      "Updated": "2026-07-01T23:31:00.9526221-07:00",
+      "Version": "3.35.1"
     },
     {
       "Info": "",
       "Name": "msys2",
       "Source": "main",
-      "Version": "2026-06-11",
-      "Updated": "2026-06-17T23:34:10.8442221-07:00"
+      "Updated": "2026-06-17T23:34:10.8442221-07:00",
+      "Version": "2026-06-11"
     },
     {
       "Info": "",
       "Name": "nasm",
       "Source": "main",
-      "Version": "3.02",
-      "Updated": "2026-06-28T23:31:42.1798232-07:00"
+      "Updated": "2026-06-28T23:31:42.1798232-07:00",
+      "Version": "3.02"
     },
     {
       "Info": "",
       "Name": "nodejs-lts",
       "Source": "main",
-      "Version": "24.18.1",
-      "Updated": "2026-07-30T20:28:31.171211-07:00"
+      "Updated": "2026-07-30T20:28:31.171211-07:00",
+      "Version": "24.18.1"
     },
     {
       "Info": "",
       "Name": "notepadplusplus",
       "Source": "extras",
-      "Version": "8.9.7",
-      "Updated": "2026-07-13T23:32:19.8334139-07:00"
+      "Updated": "2026-07-13T23:32:19.8334139-07:00",
+      "Version": "8.9.7"
     },
     {
       "Info": "",
       "Name": "obs-studio",
       "Source": "extras",
-      "Version": "32.2.2",
-      "Updated": "2026-08-14T23:33:02.2057264-07:00"
+      "Updated": "2026-08-14T23:33:02.2057264-07:00",
+      "Version": "32.2.2"
     },
     {
       "Info": "",
       "Name": "obsidian",
       "Source": "extras",
-      "Version": "1.13.7",
-      "Updated": "2026-08-12T23:33:06.1297083-07:00"
+      "Updated": "2026-08-12T23:33:06.1297083-07:00",
+      "Version": "1.13.7"
     },
     {
       "Info": "",
       "Name": "onecommander",
       "Source": "extras",
-      "Version": "3.108.0.0",
-      "Updated": "2026-04-19T12:17:19.2996727-07:00"
+      "Updated": "2026-04-19T12:17:19.2996727-07:00",
+      "Version": "3.108.0.0"
     },
     {
       "Info": "",
       "Name": "openjdk24",
       "Source": "java",
-      "Version": "24.0.2-12",
-      "Updated": "2025-08-05T18:47:19.0739965-07:00"
+      "Updated": "2025-08-05T18:47:19.0739965-07:00",
+      "Version": "24.0.2-12"
     },
     {
       "Info": "",
       "Name": "pandoc",
       "Source": "main",
-      "Version": "3.10.2",
-      "Updated": "2026-08-12T23:33:08.8584112-07:00"
+      "Updated": "2026-08-12T23:33:08.8584112-07:00",
+      "Version": "3.10.2"
     },
     {
       "Info": "",
       "Name": "php",
       "Source": "main",
-      "Version": "8.5.9",
-      "Updated": "2026-07-30T20:28:49.4271889-07:00"
+      "Updated": "2026-07-30T20:28:49.4271889-07:00",
+      "Version": "8.5.9"
     },
     {
       "Info": "",
       "Name": "pipx",
       "Source": "main",
-      "Version": "1.16.7",
-      "Updated": "2026-08-13T23:32:48.6585199-07:00"
+      "Updated": "2026-08-13T23:32:48.6585199-07:00",
+      "Version": "1.16.7"
     },
     {
       "Info": "",
       "Name": "poppler",
       "Source": "main",
-      "Version": "26.02.0-0",
-      "Updated": "2026-05-14T16:44:45.3997785-07:00"
+      "Updated": "2026-05-14T16:44:45.3997785-07:00",
+      "Version": "26.02.0-0"
     },
     {
       "Info": "",
       "Name": "powershell-beautifier",
       "Source": "main",
-      "Version": "1.2.5",
-      "Updated": "2025-05-20T13:34:07.5742884-07:00"
+      "Updated": "2025-05-20T13:34:07.5742884-07:00",
+      "Version": "1.2.5"
     },
     {
       "Info": "",
       "Name": "process-explorer",
       "Source": "sysinternals",
-      "Version": "17.13",
-      "Updated": "2026-08-12T23:33:10.1259732-07:00"
+      "Updated": "2026-08-12T23:33:10.1259732-07:00",
+      "Version": "17.13"
     },
     {
       "Info": "",
       "Name": "pshazz",
       "Source": "main",
-      "Version": "0.2022.03.09",
-      "Updated": "2025-05-20T09:49:56.2579339-07:00"
+      "Updated": "2025-05-20T09:49:56.2579339-07:00",
+      "Version": "0.2022.03.09"
     },
     {
       "Info": "",
       "Name": "pwsh",
       "Source": "main",
-      "Version": "7.6.4",
-      "Updated": "2026-07-30T20:28:52.8350604-07:00"
+      "Updated": "2026-07-30T20:28:52.8350604-07:00",
+      "Version": "7.6.4"
     },
     {
       "Info": "",
       "Name": "ripgrep",
       "Source": "main",
-      "Version": "15.2.0",
-      "Updated": "2026-07-15T10:02:31.8736287-07:00"
+      "Updated": "2026-07-15T10:02:31.8736287-07:00",
+      "Version": "15.2.0"
     },
     {
       "Info": "",
       "Name": "ruby",
       "Source": "main",
-      "Version": "4.0.6-1",
-      "Updated": "2026-07-14T23:32:23.0651878-07:00"
+      "Updated": "2026-07-14T23:32:23.0651878-07:00",
+      "Version": "4.0.6-1"
     },
     {
       "Info": "",
       "Name": "rufus",
       "Source": "extras",
-      "Version": "4.15",
-      "Updated": "2026-06-30T23:31:33.0610526-07:00"
+      "Updated": "2026-06-30T23:31:33.0610526-07:00",
+      "Version": "4.15"
     },
     {
       "Info": "",
       "Name": "rust",
       "Source": "main",
-      "Version": "1.98.0",
-      "Updated": "2026-08-20T23:36:48.9329353-07:00"
+      "Updated": "2026-08-20T23:36:48.9329353-07:00",
+      "Version": "1.98.0"
     },
     {
       "Info": "",
       "Name": "screentogif",
       "Source": "extras",
-      "Version": "2.43.2",
-      "Updated": "2026-07-30T20:32:35.554848-07:00"
+      "Updated": "2026-07-30T20:32:35.554848-07:00",
+      "Version": "2.43.2"
     },
     {
       "Info": "",
       "Name": "shfmt",
       "Source": "main",
-      "Version": "3.13.1",
-      "Updated": "2026-04-19T12:21:46.7157801-07:00"
+      "Updated": "2026-04-19T12:21:46.7157801-07:00",
+      "Version": "3.13.1"
     },
     {
       "Info": "",
       "Name": "signal",
       "Source": "extras",
-      "Version": "8.24.1",
-      "Updated": "2026-08-20T23:36:53.410341-07:00"
+      "Updated": "2026-08-20T23:36:53.410341-07:00",
+      "Version": "8.24.1"
     },
     {
       "Info": "",
       "Name": "sqlite",
       "Source": "main",
-      "Version": "3.53.4",
-      "Updated": "2026-07-30T20:32:42.9030567-07:00"
+      "Updated": "2026-07-30T20:32:42.9030567-07:00",
+      "Version": "3.53.4"
     },
     {
       "Info": "",
       "Name": "sqlitebrowser",
       "Source": "extras",
-      "Version": "3.13.1",
-      "Updated": "2025-06-17T19:57:01.1180104-07:00"
+      "Updated": "2025-06-17T19:57:01.1180104-07:00",
+      "Version": "3.13.1"
     },
     {
       "Info": "",
       "Name": "sublime-text",
       "Source": "extras",
-      "Version": "4-4200",
-      "Updated": "2026-01-05T21:38:49.7884938-08:00"
+      "Updated": "2026-01-05T21:38:49.7884938-08:00",
+      "Version": "4-4200"
     },
     {
       "Info": "",
       "Name": "sumatrapdf",
       "Source": "extras",
-      "Version": "3.6.1",
-      "Updated": "2026-04-19T12:21:53.8289846-07:00"
+      "Updated": "2026-04-19T12:21:53.8289846-07:00",
+      "Version": "3.6.1"
     },
     {
       "Info": "",
       "Name": "thunderbird-esr",
       "Source": null,
-      "Version": "128.10.1esr",
-      "Updated": "2026-08-17T21:38:43.6140203-07:00"
+      "Updated": "2026-08-17T21:38:43.6140203-07:00",
+      "Version": "128.10.1esr"
     },
     {
       "Info": "",
       "Name": "ultravnc",
       "Source": "extras",
-      "Version": "1.8.2.4",
-      "Updated": "2026-06-19T23:32:23.9436855-07:00"
+      "Updated": "2026-06-19T23:32:23.9436855-07:00",
+      "Version": "1.8.2.4"
     },
     {
       "Info": "",
       "Name": "vlc",
       "Source": "extras",
-      "Version": "3.0.23",
-      "Updated": "2026-01-08T08:25:16.6693536-08:00"
+      "Updated": "2026-01-08T08:25:16.6693536-08:00",
+      "Version": "3.0.23"
     },
     {
       "Info": "",
       "Name": "wezterm",
       "Source": "extras",
-      "Version": "20240203-110809-5046fc22",
-      "Updated": "2025-05-21T09:56:02.5341677-07:00"
+      "Updated": "2025-05-21T09:56:02.5341677-07:00",
+      "Version": "20240203-110809-5046fc22"
     },
     {
       "Info": "",
       "Name": "wget",
       "Source": "main",
-      "Version": "1.21.4",
-      "Updated": "2025-06-09T19:22:06.1569868-07:00"
+      "Updated": "2025-06-09T19:22:06.1569868-07:00",
+      "Version": "1.21.4"
     },
     {
       "Info": "",
       "Name": "whkd",
       "Source": "extras",
-      "Version": "0.2.10",
-      "Updated": "2025-09-09T23:30:51.1454061-07:00"
+      "Updated": "2025-09-09T23:30:51.1454061-07:00",
+      "Version": "0.2.10"
     },
     {
       "Info": "",
       "Name": "windhawk",
       "Source": "extras",
-      "Version": "1.7.3",
-      "Updated": "2025-12-19T23:14:13.6460205-08:00"
+      "Updated": "2025-12-19T23:14:13.6460205-08:00",
+      "Version": "1.7.3"
     },
     {
       "Info": "",
       "Name": "windows-terminal",
       "Source": "extras",
-      "Version": "1.24.11911.0",
-      "Updated": "2026-07-30T20:32:44.2013961-07:00"
+      "Updated": "2026-07-30T20:32:44.2013961-07:00",
+      "Version": "1.24.11911.0"
     },
     {
       "Info": "",
       "Name": "wixtoolset",
       "Source": "main",
-      "Version": "7.0.0",
-      "Updated": "2026-04-19T12:22:12.4226122-07:00"
+      "Updated": "2026-04-19T12:22:12.4226122-07:00",
+      "Version": "7.0.0"
     },
     {
       "Info": "",
       "Name": "wp-cli",
       "Source": "main",
-      "Version": "2.12.0",
-      "Updated": "2026-07-24T14:11:08.9534671-07:00"
+      "Updated": "2026-07-24T14:11:08.9534671-07:00",
+      "Version": "2.12.0"
     },
     {
       "Info": "",
       "Name": "yt-dlp",
       "Source": "main",
-      "Version": "2026.08.19",
-      "Updated": "2026-08-19T23:35:01.4549284-07:00"
+      "Updated": "2026-08-19T23:35:01.4549284-07:00",
+      "Version": "2026.08.19"
     }
   ],
   "buckets": [
     {
+      "Manifests": 1635,
       "Name": "main",
       "Source": "https://github.com/ScoopInstaller/Main",
-      "Updated": "2026-08-21T21:30:59-07:00",
-      "Manifests": 1635
+      "Updated": "2026-08-21T21:30:59-07:00"
     },
     {
+      "Manifests": 2371,
       "Name": "extras",
       "Source": "https://github.com/ScoopInstaller/Extras",
-      "Updated": "2026-08-21T23:26:01-07:00",
-      "Manifests": 2371
+      "Updated": "2026-08-21T23:26:01-07:00"
     },
     {
+      "Manifests": 75,
       "Name": "sysinternals",
       "Source": "https://github.com/niheaven/scoop-sysinternals",
-      "Updated": "2026-08-19T18:54:57-07:00",
-      "Manifests": 75
+      "Updated": "2026-08-19T18:54:57-07:00"
     },
     {
+      "Manifests": 132,
       "Name": "nonportable",
       "Source": "https://github.com/ScoopInstaller/Nonportable",
-      "Updated": "2026-08-21T18:53:51-07:00",
-      "Manifests": 132
+      "Updated": "2026-08-21T18:53:51-07:00"
     },
     {
+      "Manifests": 336,
       "Name": "java",
       "Source": "https://github.com/ScoopInstaller/Java",
-      "Updated": "2026-08-21T21:33:00-07:00",
-      "Manifests": 336
+      "Updated": "2026-08-21T21:33:00-07:00"
     }
   ]
 }

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,15 @@
 # Plan
 
-## Current milestone: scoop host-health tooling (issue #70)
+## Current milestone: backup upload diagnostics (issue #46)
+
+- [x] RCA the recurring `backup steps failed: 2` auto-backup commits from repository evidence: failing step names were console-only, so ten days of partial-failure uploads (2026-08-12..2026-08-22) were undiagnosable from git history.
+- [x] Name failing steps in the backup commit message (`(backup steps failed: N [StepA, StepB]; X/Y succeeded)`), policy-pinned in the conventions suite.
+- [x] Eliminate the daily whole-file `Config/scoopfile.json` churn caused by `scoop export`'s non-deterministic app-member ordering: opt-in `-SortObjectKeys` canonicalization (Ordinal member sort, arrays untouched, fail-closed duplicate handling), ScoopBackup opts in, committed artifact regenerated as a fixed point of both modes.
+- [ ] After the next host backup run: read the named failing steps from the commit message and continue the issue #46 investigation with that evidence.
+
+Evidence: [session-022](./progress/session-022-backup-upload-diagnostics.md)
+
+## Completed milestone: scoop host-health tooling (issue #70)
 
 - [x] Implement `Scripts/Scoop/Invoke-ScoopHealthCheck.ps1` covering every audited failure mode: `scoop status` anomalies (Install failed / Manifest removed / missing versions), installed-vs-bucket version inversion (the `2025 > 2.71.0` deadlock), junction integrity (`current` reparse-point checks), Mozilla channel drift against real `compatibility.ini` `LastVersion=<version>_<buildId>/<prev>` shapes, and orphaned Mozilla helper processes.
 - [x] Honor `$env:SCOOP_GLOBAL` (admin/global installs) in both the health check and ScoopRestore's Mozilla policy deployment, single-sourced through `Scripts/Utils/Common/ScoopInstallRootHelpers.ps1` (closes the gap noted during PR #69 review).

--- a/Scripts/Backup.ps1
+++ b/Scripts/Backup.ps1
@@ -965,7 +965,12 @@ try {
     if (-not $hasGitFailure) {
         if ($stagedFiles.Count -gt 0) {
             if ($hasBackupStepFailures) {
-                $commitMessage = "Backup for $dateString (backup steps failed: $failedCount; $succeededCount/$totalCount succeeded)"
+                # Name the failing steps in the commit message itself: the summary above is console-only,
+                # while this message persists in git history, so partial-failure runs remain diagnosable
+                # from the log alone instead of requiring access to the host console.
+                $failedStepNames = @($failedSteps | ForEach-Object { $_.Name })
+                $failedStepsText = $failedStepNames -join ', '
+                $commitMessage = "Backup for $dateString (backup steps failed: $failedCount [$failedStepsText]; $succeededCount/$totalCount succeeded)"
             }
             else {
                 $commitMessage = "Backup for $dateString ($succeededCount/$totalCount)"

--- a/Scripts/Scoop/ScoopBackup.ps1
+++ b/Scripts/Scoop/ScoopBackup.ps1
@@ -19,6 +19,13 @@ function ConvertTo-CanonicalScoopExportJson {
     # every line. The shared helper parses via System.Text.Json's JsonDocument so the ISO-8601 `Updated`
     # timestamps are preserved verbatim (ConvertFrom-Json/ConvertTo-Json would reparse and timezone-shift
     # them); see Scripts/Utils/Common/CanonicalJsonHelpers.ps1 for the full contract.
+    #
+    # -SortObjectKeys is load-bearing for stability: scoop builds each exported app object from a
+    # PowerShell hashtable, whose iteration order differs per invocation, so successive `scoop export`
+    # runs emit identical data with different member order. Without sorting, every daily backup rewrote
+    # all ~680 lines of scoopfile.json (observed 2026-08-12..2026-08-22), drowning real changes in noise.
+    # Sorting member names Ordinally makes the bytes data-determined; pretty-format-json preserves key
+    # order, so the sorted form remains hook-identical.
     [OutputType([string])]
     [CmdletBinding()]
     param(
@@ -27,7 +34,7 @@ function ConvertTo-CanonicalScoopExportJson {
         [string]$RawJson
     )
 
-    return ConvertTo-CanonicalJsonText -RawJson $RawJson
+    return ConvertTo-CanonicalJsonText -RawJson $RawJson -SortObjectKeys
 }
 
 function Invoke-ScoopBackup {

--- a/Scripts/Utils/Common/CanonicalJsonHelpers.ps1
+++ b/Scripts/Utils/Common/CanonicalJsonHelpers.ps1
@@ -77,6 +77,82 @@ function ConvertTo-AsciiEscapedJsonText {
     return $builder.ToString()
 }
 
+function ConvertTo-JsonNodeWithSortedObjectKeys {
+    # Rebuilds a System.Text.Json.Nodes JsonNode tree so every JSON object's properties appear in
+    # [System.StringComparer]::Ordinal key order, recursively. Array element order is preserved (only
+    # object MEMBERS are reordered -- never array items). This exists because some upstream generators,
+    # notably `scoop export` (which builds each app object from a PowerShell hashtable whose iteration
+    # order varies per invocation), emit the same data with different member order on every run: without
+    # sorting, a byte-stable committed artifact is impossible and backups churn whole-file diffs daily.
+    #
+    # Leaf values are copied by round-tripping their exact JSON text through JsonNode so string payloads
+    # (ISO-8601 timestamps), number tokens, booleans, and nulls survive verbatim without type-specific
+    # GetValue<T> probing. Duplicate input member names cannot be represented by a rebuilt JsonObject:
+    # JsonNode.Parse rejects them outright, and ConvertTo-CanonicalJsonText wraps that failure in the
+    # stable E_CANONICAL_JSON_SORT_FAILED diagnostic so it fails CLOSED instead of silently dropping data.
+    # Callers must runtime-gate invocation on "System.Text.Json.Nodes.JsonNode" -as [type]; Windows
+    # PowerShell 5.1 never reaches this function.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '', Justification = 'System.Text.Json.Nodes is runtime-gated to PowerShell 7+ via a "...JsonNode" -as [type]" probe at the call site; Windows PowerShell 5.1 never invokes this function. This is the sanctioned runtime-guarded pattern in .llm/context.md.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [System.Text.Json.Nodes.JsonNode]$Node
+    )
+
+    if ($null -eq $Node) {
+        return $null
+    }
+
+    if ($Node -is [System.Text.Json.Nodes.JsonObject]) {
+        $sortedObject = [System.Text.Json.Nodes.JsonObject]::new()
+        # Ordinal insertion sort over the member pairs: deterministic across machines and cultures
+        # (context.md portability rule 15) with no follow-up key lookup. Object member counts here are
+        # tiny (scoop app objects carry five members), so quadratic insertion cost is irrelevant.
+        $sortedPairs = New-Object System.Collections.Generic.List[object]
+        foreach ($property in $Node.AsObject()) {
+            $insertIndex = $sortedPairs.Count
+            for ($pairIndex = 0; $pairIndex -lt $sortedPairs.Count; $pairIndex++) {
+                $ordinalComparison = [System.String]::CompareOrdinal($property.Key, [string]$sortedPairs[$pairIndex].Key)
+                if ($ordinalComparison -lt 0) {
+                    $insertIndex = $pairIndex
+                    break
+                }
+            }
+
+            $sortedPairs.Insert($insertIndex, $property)
+        }
+
+        foreach ($pair in $sortedPairs) {
+            $sortedChild = ConvertTo-JsonNodeWithSortedObjectKeys -Node $pair.Value
+            [void]$sortedObject.Add([string]$pair.Key, $sortedChild)
+        }
+
+        # Comma-wrapped returns throughout: JsonObject/JsonArray implement IDictionary/IEnumerable, so
+        # bare `return $node` would be UNROLLED by the PowerShell pipeline into KeyValuePairs/elements and
+        # callers would receive object[] instead of the rebuilt node (see .llm/context.md "PowerShell Empty
+        # Array Return Safety"). The comma operator preserves the node as a single pipeline item.
+        return , $sortedObject
+    }
+
+    if ($Node -is [System.Text.Json.Nodes.JsonArray]) {
+        $sortedArray = [System.Text.Json.Nodes.JsonArray]::new()
+        foreach ($element in $Node.AsArray()) {
+            $sortedChild = ConvertTo-JsonNodeWithSortedObjectKeys -Node $element
+            [void]$sortedArray.Add($sortedChild)
+        }
+
+        # Comma-wrapped return: JsonArray is IEnumerable, so a bare `return $sortedArray` would be
+        # unrolled by the PowerShell pipeline into its elements and callers would receive object[]
+        # instead of the rebuilt node (see .llm/context.md "PowerShell Empty Array Return Safety").
+        return , $sortedArray
+    }
+
+    # Leaf value: copy via its exact serialized text (comma-wrapped for the same pipeline-unroll safety).
+    $rawLeafText = $Node.ToJsonString()
+    return , ([System.Text.Json.JsonSerializer]::Deserialize($rawLeafText, [System.Text.Json.Nodes.JsonNode]))
+}
+
 function ConvertTo-CanonicalJsonText {
     # Re-emits JSON in the repository's canonical committed form -- 2-space indent, LF newlines, exactly
     # one trailing newline, non-ASCII escaped to \uXXXX -- byte-identical to the pre-commit
@@ -98,14 +174,29 @@ function ConvertTo-CanonicalJsonText {
     # exactly what `pretty-format-json`/`check-json` require. On Windows PowerShell 5.1, where
     # System.Text.Json is unavailable, it falls back to line-ending/trailing-newline normalization only and
     # an attended commit's hook canonicalizes the indentation; timestamps are still preserved (no reparse).
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '', Justification = 'System.Text.Json is runtime-gated to PowerShell 7+ via a "...-as [type]" probe; Windows PowerShell 5.1 takes the line-ending-normalizing fallback. This is the sanctioned runtime-guarded pattern in .llm/context.md.')]
+    #
+    # -SortObjectKeys additionally rebuilds every JSON object with Ordinal-sorted member names (nested
+    # recursively; array element order untouched) before serialization, for upstream generators whose own
+    # member order is non-deterministic across runs (`scoop export` app objects built from PowerShell
+    # hashtables). The sorted form stays a byte-identical fixed point of `pretty-format-json` because that
+    # hook preserves key order -- sorting at the source is what removes the daily whole-file churn.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '', Justification = 'System.Text.Json (including Nodes for -SortObjectKeys) is runtime-gated to PowerShell 7+ via a "...-as [type]" probe; Windows PowerShell 5.1 takes the line-ending-normalizing fallback. This is the sanctioned runtime-guarded pattern in .llm/context.md.')]
     [OutputType([string])]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
-        [string]$RawJson
+        [string]$RawJson,
+
+        [switch]$SortObjectKeys
     )
+
+    # Sorted-path availability is probed once up front so BOTH degradation modes (no System.Text.Json at
+    # all on Windows PowerShell 5.1, or an older Core build without the Nodes API) surface the same
+    # actionable warning instead of silently returning unsorted output.
+    if ($SortObjectKeys -and $null -eq ("System.Text.Json.Nodes.JsonNode" -as [type])) {
+        Write-Warning "W_CANONICAL_JSON_SORT_UNAVAILABLE: -SortObjectKeys was requested but System.Text.Json.Nodes is unavailable on this runtime; output member order was NOT normalized."
+    }
 
     $jsonDocumentType = "System.Text.Json.JsonDocument" -as [type]
     if ($null -ne $jsonDocumentType) {
@@ -114,16 +205,45 @@ function ConvertTo-CanonicalJsonText {
             $documentOptions = [System.Text.Json.JsonDocumentOptions]::new()
             $documentOptions.CommentHandling = [System.Text.Json.JsonCommentHandling]::Skip
             $documentOptions.AllowTrailingCommas = $true
-            $document = [System.Text.Json.JsonDocument]::Parse($RawJson, $documentOptions)
 
             $serializerOptions = [System.Text.Json.JsonSerializerOptions]::new()
             $serializerOptions.WriteIndented = $true
             $serializerOptions.Encoder = [System.Text.Encodings.Web.JavaScriptEncoder]::UnsafeRelaxedJsonEscaping
 
+            # Sorted path: parse into an editable JsonNode tree, rebuild it Ordinal-sorted, and serialize
+            # the rebuilt tree through the same serializer options as the default path so formatting is
+            # identical. A scalar "null" document parses to a null node and falls through to the default
+            # path, which has no member order to sort.
+            $sortedRootNode = $null
+            if ($SortObjectKeys) {
+                $jsonNodeType = "System.Text.Json.Nodes.JsonNode" -as [type]
+                if ($null -ne $jsonNodeType) {
+                    try {
+                        $jsonNodeOptions = [System.Text.Json.Nodes.JsonNodeOptions]::new()
+                        $jsonNodeOptions.PropertyNameCaseInsensitive = $false
+                        $sortedRootNode = ConvertTo-JsonNodeWithSortedObjectKeys -Node ($jsonNodeType::Parse($RawJson, $jsonNodeOptions, $documentOptions))
+                    }
+                    catch {
+                        # Fail closed with a stable code: unlike the default path, a sorted rebuild cannot
+                        # represent every input (duplicate member names are rejected by JsonNode.Parse), so
+                        # callers must never mistake a silent unsorted fallback for success.
+                        $sortFailureDetail = [string]$_.Exception.Message
+                        throw ("E_CANONICAL_JSON_SORT_FAILED: -SortObjectKeys could not rebuild the JSON tree for sorted serialization. Detail: {0}" -f $sortFailureDetail)
+                    }
+                }
+            }
+
             # WriteIndented uses CRLF on .NET running under Windows (the indented Utf8JsonWriter newline was
             # hard-coded to "`r`n" before .NET 9 / the configurable JsonWriterOptions.NewLine). The LF
             # normalization below is what makes the output LF-only on every platform, not just Linux/macOS.
-            $serialized = [System.Text.Json.JsonSerializer]::Serialize($document.RootElement, $serializerOptions)
+            if ($null -ne $sortedRootNode) {
+                $serialized = [System.Text.Json.JsonSerializer]::Serialize($sortedRootNode, $serializerOptions)
+            }
+            else {
+                $document = [System.Text.Json.JsonDocument]::Parse($RawJson, $documentOptions)
+                $serialized = [System.Text.Json.JsonSerializer]::Serialize($document.RootElement, $serializerOptions)
+            }
+
             $serialized = ConvertTo-AsciiEscapedJsonText -Text $serialized
             return (ConvertTo-LfTextWithSingleTrailingNewline -Text $serialized)
         }

--- a/Tests/Scoop/ScoopBackup.Tests.ps1
+++ b/Tests/Scoop/ScoopBackup.Tests.ps1
@@ -7,9 +7,10 @@ BeforeAll {
     # the pure functions for testing.
     . "$PSScriptRoot/../../Scripts/Scoop/ScoopBackup.ps1"
 
-    # A representative `scoop export` payload in scoop's native 4-space indentation, including the
-    # ISO-8601 `Updated` timestamps (with timezone offset and sub-second precision) that must survive
-    # canonicalization verbatim.
+    # A representative `scoop export` payload in scoop's native 4-space indentation. Object member order
+    # is deliberately NOT alphabetical (scoop builds app objects from hashtables, so real exports arrive
+    # in varying orders), including the ISO-8601 `Updated` timestamps (with timezone offset and sub-second
+    # precision) that must survive canonicalization verbatim.
     $script:rawFourSpace = @"
 {
     "buckets": [
@@ -27,6 +28,30 @@ BeforeAll {
             "Version": "24.09",
             "Updated": "2026-04-27T23:30:18.9329513-07:00",
             "Info": ""
+        }
+    ]
+}
+"@ -replace "`r`n", "`n"
+
+    # The same data with every object's members emitted in a different order: scoop export produces this
+    # kind of permutation on another day/run, and the canonical output must be byte-identical for both.
+    $script:rawFourSpacePermuted = @"
+{
+    "apps": [
+        {
+            "Info": "",
+            "Updated": "2026-04-27T23:30:18.9329513-07:00",
+            "Version": "24.09",
+            "Name": "7zip",
+            "Source": "main"
+        }
+    ],
+    "buckets": [
+        {
+            "Manifests": 1579,
+            "Updated": "2026-06-19T22:48:12-07:00",
+            "Source": "https://github.com/ScoopInstaller/Main",
+            "Name": "main"
         }
     ]
 }
@@ -70,6 +95,11 @@ Describe "ConvertTo-CanonicalScoopExportJson" {
     }
 
     It "produces a stable fixed point (canonicalizing the output again yields identical bytes)" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "byte-exact canonical form requires System.Text.Json"
+            return
+        }
+
         # The committed file must be a fixed point of the formatter so attended (hook) and unattended
         # (--no-verify) backup commits land identical bytes, which is what prevents the merge conflicts.
         $once = ConvertTo-CanonicalScoopExportJson -RawJson $script:rawFourSpace
@@ -85,11 +115,39 @@ Describe "ConvertTo-CanonicalScoopExportJson" {
 
         $canonical = ConvertTo-CanonicalScoopExportJson -RawJson $script:rawFourSpace
         $lines = $canonical -split "`n"
-        ($lines[1]) | Should -Be '  "buckets": [' -Because "top-level members must use 2-space indentation"
+        # Member names sort Ordinally, so "apps" precedes "buckets" at the top level.
+        ($lines[1]) | Should -Be '  "apps": [' -Because "top-level members must use 2-space indentation and sorted key order"
         # The deepest nested members sit at 6 spaces (member -> array -> object) under 2-space indent.
         @($lines | Where-Object { $_ -match '^      "Name": "main"' }).Count | Should -BeGreaterThan 0
         # No residual 4-space (scoop) indentation for a top-level key.
         $canonical | Should -Not -Match '(?m)^    "buckets":'
+    }
+
+    It "emits object members in Ordinal-sorted order regardless of scoop's per-run ordering" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "member sorting requires System.Text.Json (Windows PowerShell 5.1 fallback cannot rewrite JSON)"
+            return
+        }
+
+        $canonical = ConvertTo-CanonicalScoopExportJson -RawJson $script:rawFourSpace
+        $canonicalFromPermutation = ConvertTo-CanonicalScoopExportJson -RawJson $script:rawFourSpacePermuted
+        $canonicalFromPermutation | Should -BeExactly $canonical -Because "identical data must produce identical bytes no matter what member order scoop emitted"
+
+        # Pin the deterministic shape: nested members appear Ordinally sorted inside BOTH arrays
+        # (app: Info, Name, Source, Updated, Version; bucket: Manifests, Name, Source, Updated) and the
+        # ISO timestamps survive verbatim inside the sorted form.
+        $memberLines = @($canonical -split "`n" | Where-Object { $_ -match '^      "' })
+        $memberLines | Should -BeExactly @(
+            '      "Info": "",'
+            '      "Name": "7zip",'
+            '      "Source": "main",'
+            '      "Updated": "2026-04-27T23:30:18.9329513-07:00",'
+            '      "Version": "24.09"'
+            '      "Manifests": 1579,'
+            '      "Name": "main",'
+            '      "Source": "https://github.com/ScoopInstaller/Main",'
+            '      "Updated": "2026-06-19T22:48:12-07:00"'
+        )
     }
 
     It "accepts an already-canonical payload unchanged (idempotent on canonical input)" {

--- a/Tests/Utils/CanonicalJsonHelpers.Tests.ps1
+++ b/Tests/Utils/CanonicalJsonHelpers.Tests.ps1
@@ -119,6 +119,141 @@ Describe "ConvertTo-CanonicalJsonText" {
     }
 }
 
+Describe "ConvertTo-CanonicalJsonText -SortObjectKeys" {
+    # Regression guard for the daily whole-file scoopfile.json churn (2026-08-12..2026-08-22): scoop
+    # export rebuilds app objects from hashtables whose iteration order differs per invocation, so the
+    # canonicalizer must be able to make the bytes data-determined by sorting member names Ordinally.
+
+    It "preserves source member order by default (no switch)" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "member-order preservation requires System.Text.Json"
+            return
+        }
+
+        # Other canonicalizer consumers rely on order preservation; sorting must be strictly opt-in.
+        $canonical = ConvertTo-CanonicalJsonText -RawJson '{ "b": 1, "a": 2 }'
+        $canonical | Should -BeExactly "{`n  `"b`": 1,`n  `"a`": 2`n}`n"
+    }
+
+    It "sorts <description> with -SortObjectKeys" -ForEach @(
+        @{
+            description = "top-level members alphabetically"
+            source      = '{ "buckets": {}, "apps": {} }'
+            expected    = "{`n  `"apps`": {},`n  `"buckets`": {}`n}`n"
+        }
+        @{
+            description = "members Ordinally (uppercase before lowercase, culture-independent)"
+            source      = '{ "a": 1, "B": 2 }'
+            expected    = "{`n  `"B`": 2,`n  `"a`": 1`n}`n"
+        }
+        @{
+            description = "an empty-string member name first"
+            source      = '{ "b": 2, "": 1 }'
+            expected    = "{`n  `"`": 1,`n  `"b`": 2`n}`n"
+        }
+        @{
+            description = "nested objects recursively"
+            source      = '{ "outer": { "z": 1, "a": { "y": 2, "b": 3 } } }'
+            expected    = "{`n  `"outer`": {`n    `"a`": {`n      `"b`": 3,`n      `"y`": 2`n    },`n    `"z`": 1`n  }`n}`n"
+        }
+    ) {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "member sorting requires System.Text.Json"
+            return
+        }
+
+        (ConvertTo-CanonicalJsonText -RawJson $source -SortObjectKeys) | Should -BeExactly $expected
+    }
+
+    It "fails closed with a stable diagnostic on duplicate member names instead of dropping data" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "duplicate-member rejection requires System.Text.Json"
+            return
+        }
+
+        # The unsorted path preserves duplicate members; a sorted rebuild cannot represent them, so it
+        # must surface E_CANONICAL_JSON_SORT_FAILED rather than silently returning unsorted output.
+        { ConvertTo-CanonicalJsonText -RawJson '{ "a": 1, "a": 2 }' -SortObjectKeys } |
+            Should -Throw 'E_CANONICAL_JSON_SORT_FAILED*'
+    }
+
+    It "produces byte-identical output for differently ordered inputs (permutation invariance)" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "permutation invariance requires System.Text.Json"
+            return
+        }
+
+        $first = ConvertTo-CanonicalJsonText -RawJson '{ "Name": "main", "Manifests": 5, "Source": "x" }' -SortObjectKeys
+        $second = ConvertTo-CanonicalJsonText -RawJson '{ "Source": "x", "Name": "main", "Manifests": 5 }' -SortObjectKeys
+        $second | Should -BeExactly $first
+        $first | Should -BeExactly "{`n  `"Manifests`": 5,`n  `"Name`": `"main`",`n  `"Source`": `"x`"`n}`n"
+    }
+
+    It "preserves array element order while sorting members of objects inside arrays" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "array-aware sorting requires System.Text.Json"
+            return
+        }
+
+        # Array ITEMS must never be reordered -- only object members within them.
+        $canonical = ConvertTo-CanonicalJsonText -RawJson '{ "apps": [ { "Version": "1", "Name": "zeta" }, { "Version": "2", "Name": "alpha" } ] }' -SortObjectKeys
+        $parsed = $canonical | ConvertFrom-Json
+        @($parsed.apps).Count | Should -Be 2
+        $parsed.apps[0].Name | Should -Be "zeta"
+        $parsed.apps[1].Name | Should -Be "alpha"
+
+        ($canonical -split "`n") | Where-Object { $_ -match '"Name"' } | Should -BeExactly @(
+            '      "Name": "zeta",'
+            '      "Name": "alpha",'
+        ) -Because "members inside each array element must appear sorted (Name before Version)"
+    }
+
+    It "keeps leaf payloads verbatim under sorting (timestamps, number tokens, literals)" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "leaf fidelity checks require System.Text.Json"
+            return
+        }
+
+        $raw = '{ "Updated": "2026-04-27T23:30:18.9329513-07:00", "Ratio": 1.50, "On": true, "Nothing": null }'
+        $canonical = ConvertTo-CanonicalJsonText -RawJson $raw -SortObjectKeys
+        $canonical | Should -Match ([regex]::Escape('"Updated": "2026-04-27T23:30:18.9329513-07:00"'))
+        $canonical | Should -Not -Match '\+00:00' -Because "timestamps must not be normalized to UTC"
+        $canonical | Should -Match ([regex]::Escape('"Ratio": 1.50')) -Because "number tokens must not be re-formatted"
+        $canonical | Should -Match ([regex]::Escape('"Nothing": null'))
+        ($canonical | ConvertFrom-Json).On | Should -BeTrue
+    }
+
+    It "is idempotent under -SortObjectKeys (sorted output re-canonicalizes to identical bytes)" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "idempotence requires System.Text.Json"
+            return
+        }
+
+        $once = ConvertTo-CanonicalJsonText -RawJson '{ "b": [ { "y": 1, "a": 2 } ], "a": "x" }' -SortObjectKeys
+        $twice = ConvertTo-CanonicalJsonText -RawJson $once -SortObjectKeys
+        $twice | Should -BeExactly $once
+    }
+
+    It "tolerates JSONC comments and trailing commas on the sorted path" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "JSONC tolerance on the sorted path requires System.Text.Json"
+            return
+        }
+
+        $canonical = ConvertTo-CanonicalJsonText -RawJson "{ // comment`n  `"b`": 1,`n  `"a`": 2,`n}" -SortObjectKeys
+        $canonical | Should -BeExactly "{`n  `"a`": 2,`n  `"b`": 1`n}`n"
+    }
+
+    It "leaves a scalar-null document unchanged on the sorted path" {
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "scalar handling requires System.Text.Json"
+            return
+        }
+
+        (ConvertTo-CanonicalJsonText -RawJson 'null' -SortObjectKeys) | Should -BeExactly "null`n"
+    }
+}
+
 Describe "Committed JSON artifacts are byte-identical to the canonicalizer" {
     # The strongest guard: every committed artifact under pretty-format-json scope must already be a fixed
     # point of the shared canonicalizer, proving the canonicalizer reproduces the hook output byte-for-byte.
@@ -138,6 +273,20 @@ Describe "Committed JSON artifacts are byte-identical to the canonicalizer" {
         $fullPath = Join-Path -Path $script:repoRoot -ChildPath $path
         $raw = [System.IO.File]::ReadAllText($fullPath, [System.Text.Encoding]::UTF8)
         (ConvertTo-CanonicalJsonText -RawJson $raw) | Should -BeExactly $raw -Because "$path must be a fixed point of the pretty-format-json hook"
+    }
+
+    It "reproduces Config/scoopfile.json exactly under -SortObjectKeys (data-determined member order)" {
+        # scoopfile.json is written by ScoopBackup through -SortObjectKeys because `scoop export` emits
+        # app members in varying order per invocation. The committed form must therefore also be a fixed
+        # point of the SORTED canonicalizer, proving the daily backup cannot churn whole-file diffs again.
+        if (-not $script:hasSystemTextJson) {
+            Set-ItResult -Skipped -Because "byte-exact canonical form requires System.Text.Json"
+            return
+        }
+
+        $fullPath = Join-Path -Path $script:repoRoot -ChildPath "Config/scoopfile.json"
+        $raw = [System.IO.File]::ReadAllText($fullPath, [System.Text.Encoding]::UTF8)
+        (ConvertTo-CanonicalJsonText -RawJson $raw -SortObjectKeys) | Should -BeExactly $raw -Because "the committed scoopfile.json must already be in sorted-key canonical form"
     }
 }
 

--- a/Tests/Utils/ScriptSafetyConventions.Tests.ps1
+++ b/Tests/Utils/ScriptSafetyConventions.Tests.ps1
@@ -3593,7 +3593,8 @@ Describe "Backup script safety conventions" {
         $backupScript | Should -Match 'param\(\s*\[Parameter\(Mandatory\s*=\s*\$false\)\]\s*\[switch\]\$Unattended\s*\)'
         $backupScript | Should -Match 'WALLSTOP_BACKUP_UNATTENDED'
         $backupScript | Should -Match 'function\s+Test-BackupTruthySettingValue'
-        $backupScript | Should -Match 'if\s*\(\s*\$hasBackupStepFailures\s*\)\s*\{[\s\S]*backup steps failed: \$failedCount; \$succeededCount/\$totalCount succeeded'
+        $backupScript | Should -Match 'if\s*\(\s*\$hasBackupStepFailures\s*\)\s*\{[\s\S]*backup steps failed: \$failedCount \[\$failedStepsText\]; \$succeededCount/\$totalCount succeeded' -Because "partial-failure backup commits must name the failing steps in the persistent commit message (issue #46), not just in console-only output."
+        $backupScript | Should -Match '\$failedStepNames\s*=\s*@\(\$failedSteps\s*\|\s*ForEach-Object\s*\{\s*\$_\.Name\s*\}\)'
         $backupScript | Should -Match 'else\s*\{[\s\S]*\$commitMessage\s*=\s*"Backup for \$dateString \(\$succeededCount/\$totalCount\)"'
         $backupScript | Should -Match 'Resolve-PowerShellExecutablePath'
         $backupScript | Should -Not -Match 'Get-Command\s+-Name\s+"pwsh"'

--- a/progress/session-022-backup-upload-diagnostics.md
+++ b/progress/session-022-backup-upload-diagnostics.md
@@ -1,0 +1,73 @@
+# Session 022 — Backup upload diagnostics (issue #46)
+
+## Objective
+
+Issue #46 ("research: Investigate partial git uploads — why?") was the only open issue with
+repo-actionable work left (issues #68/#70 repo-side items are complete; their remaining items are
+operator actions on the primary Windows host). Main CI was already green and no draft PRs were
+open, so this session root-caused the visible upload pathology from repository data alone.
+
+## RCA from repository evidence
+
+1. **Unnamed partial failures.** Every unattended auto-backup since 2026-08-12 committed
+   `backup steps failed: 2; 8/10 succeeded` — but the failing step names exist only in host console
+   output. Ten days of partial-failure commits were undiagnosable from git history alone.
+2. **Whole-file scoopfile.json churn.** Each daily backup rewrote all ~680 lines of
+   `Config/scoopfile.json` with zero data change: `scoop export` builds each app object from a
+   PowerShell hashtable whose member iteration order differs per invocation, so the member order
+   changed every run (observed three distinct orderings across Aug 20–22 commits).
+3. **Likely failing steps** (unconfirmed until tomorrow's run names them): `ScoopUpdate` and/or
+   `WinGetUpdate`, consistent with the broken package state documented in issue #68 before the
+   on-host fixes (thunderbird-esr manifest removed, megatools half-install) and WinGet's
+   any-package-failure exit semantics.
+
+## What shipped
+
+1. **`Scripts/Backup.ps1`**: the partial-failure commit message now interpolates failed step names:
+   `(backup steps failed: N [StepA, StepB]; X/Y succeeded)`. Future failures self-identify from
+   `git log` with no host access.
+2. **`Scripts/Utils/Common/CanonicalJsonHelpers.ps1`**: new opt-in `-SortObjectKeys` mode for
+   `ConvertTo-CanonicalJsonText`, backed by a new recursive `ConvertTo-JsonNodeWithSortedObjectKeys`
+   helper (System.Text.Json.Nodes.JsonNode; Ordinal insertion sort; arrays never reordered; leaves
+   round-tripped through exact JSON text so timestamps/number tokens survive verbatim). Duplicate
+   member names fail closed (`E_CANONICAL_JSON_SORT_FAILED`; JsonNode.Parse rejects them); missing
+   Nodes support degrades loudly once (`W_CANONICAL_JSON_SORT_UNAVAILABLE`). Comma-wrapped returns
+   prevent PowerShell pipeline unrolling of JsonObject/JsonArray.
+3. **`Scripts/Scoop/ScoopBackup.ps1`**: wrapper passes `-SortObjectKeys`. Because
+   `pretty-format-json` runs with `--no-sort-keys`, sorted output remains hook-identical;
+   `Config/scoopfile.json` was regenerated once into sorted-canonical form (parsed data verified
+   byte-identical to HEAD).
+
+## Tests
+
+- `Tests/Utils/CanonicalJsonHelpers.Tests.ps1`: sorted-order table (incl. empty-string keys and
+  Ordinal case ordering), permutation invariance, nested recursion, array-order preservation, leaf
+  fidelity, idempotence, JSONC tolerance, scalar-null, duplicate-key fail-closed throw, default-mode
+  order preservation, and a committed-artifact guard that `Config/scoopfile.json` is a fixed point
+  of BOTH canonicalizer modes.
+- `Tests/Scoop/ScoopBackup.Tests.ps1`: key-permutation invariance fixture plus full deterministic
+  shape pinning; 5.1-lane skip guards tightened.
+- `Tests/Utils/ScriptSafetyConventions.Tests.ps1`: policy now pins the names-bearing commit-message
+  format and its derivation from `$failedSteps`.
+
+## Validation evidence
+
+- `Invoke-FullValidation.ps1 -PreflightOnly`: pass.
+- Pester gates (exit 0): `Tests/Utils/CanonicalJsonHelpers.Tests.ps1`, `Tests/Scoop`,
+  `Tests/Utils/ScriptSafetyConventions.Tests.ps1`, `Tests/Utils/BackupDxMessaging.Tests.ps1`,
+  `Tests/Utils/CompatibilityConventions.Tests.ps1`.
+- `Invoke-CompatibilityChecks.ps1` over the three changed scripts: PASS across 5.1 + pwsh7 profiles.
+- Managed `pre-commit run` (staged + full hook set): all hooks Passed, including
+  `pretty format json` against the regenerated artifact.
+
+## Review loop
+
+Adversarial reviewer found 4 issues (1 MAJOR: duplicate-key comment documented nonexistent behavior;
+silent unsorted degradation; dead defensive branch; coverage gaps). All four were fixed and an
+adversarial verifier confirmed each RESOLVED with no new findings ("exceptional, zero issues").
+
+## Follow-ups
+
+- Tomorrow's backup commit will name the two persistently failing steps; if they are
+  `ScoopUpdate`/`WinGetUpdate`, RCA continues under issue #46 with concrete evidence.
+- Issue #68/#70 remaining items stay operator-side (window-control.ahk redeploy on the primary host).


### PR DESCRIPTION
## Summary

Root-causes issue #46 ("Investigate partial git uploads — why?") from repository evidence and lands
the two fixes that make partial-failure auto-uploads self-diagnosing and byte-stable.

### RCA (data-backed)

1. **Unnamed partial failures.** Every unattended auto-backup since 2026-08-12 committed
   `backup steps failed: 2; 8/10 succeeded` without identifying which steps failed — the per-step
   summary is console-only on the host, so ten days of partial-failure uploads were undiagnosable
   from git history alone.
2. **Whole-file `Config/scoopfile.json` churn.** Each daily backup rewrote all ~680 lines of
   `scoopfile.json` with zero data change: `scoop export` builds each app object from a PowerShell
   hashtable whose member iteration order differs per invocation (three distinct member orderings are
   visible across the Aug 20–22 backup commits alone). The noise drowned real changes and made
   uploads look broken/partial.
3. **Probable failing steps** (unconfirmed until tomorrow's commit names them): `ScoopUpdate` and/or
   `WinGetUpdate`, consistent with the pre-audit package state in issue #68 (thunderbird-esr manifest
   removed, megatools half-install) and WinGet's any-package-failure exit semantics.

### Changes

- **`Scripts/Backup.ps1`**: the partial-failure commit message now interpolates failed step names:
  `(backup steps failed: N [StepA, StepB]; X/Y succeeded)`. Future failures self-identify from
  `git log` with no host access. Policy-pinned in the conventions suite.
- **`Scripts/Utils/Common/CanonicalJsonHelpers.ps1`**: new opt-in `-SortObjectKeys` mode for
  `ConvertTo-CanonicalJsonText`, backed by a recursive `ConvertTo-JsonNodeWithSortedObjectKeys`
  helper:
  - System.Text.Json.Nodes.JsonNode (runtime-gated pwsh7+ like the rest of the helper); Windows
    PowerShell 5.1 keeps the documented line-ending-only fallback.
  - Ordinal insertion sort over member pairs (`[System.String]::CompareOrdinal`) — deterministic
    across machines/cultures; array element order is never reordered; leaves round-trip through their
    exact JSON text so ISO timestamps and number tokens survive verbatim.
  - Comma-wrapped returns throughout: JsonObject/JsonArray implement IDictionary/IEnumerable, so bare
    returns get UNROLLED by the PowerShell pipeline (observed and fixed during development).
  - Duplicate member names fail CLOSED with stable `E_CANONICAL_JSON_SORT_FAILED`; missing Nodes
    support degrades loudly once with `W_CANONICAL_JSON_SORT_UNAVAILABLE`.
- **`Scripts/Scoop/ScoopBackup.ps1`**: wrapper passes `-SortObjectKeys`. `pretty-format-json` runs
  with `--no-sort-keys`, so sorted output remains hook-identical; `Config/scoopfile.json` is
  regenerated once into sorted-canonical form (parsed data verified identical to the previous HEAD;
  the artifact is now a fixed point of BOTH canonicalizer modes, asserted by test).
- **Tests**: `Tests/Utils/CanonicalJsonHelpers.Tests.ps1` (sorted-order table incl. empty-string keys
  and Ordinal case ordering, permutation invariance, nested recursion, array-order preservation, leaf
  fidelity, idempotence, JSONC tolerance, scalar-null, duplicate-key fail-closed throw, default-mode
  order preservation, committed-artifact dual-mode fixed point), `Tests/Scoop/ScoopBackup.Tests.ps1`
  (key-permutation fixture, full deterministic shape pinning, tightened 5.1 skip guards),
  `Tests/Utils/ScriptSafetyConventions.Tests.ps1` (names-bearing commit-message policy).
- **PLAN.md / progress**: new milestone recorded; [session-022](./progress/session-022-backup-upload-diagnostics.md).

## Validation

- `Invoke-FullValidation.ps1 -PreflightOnly`: pass.
- Pester gates (exit 0): `Tests/Utils/CanonicalJsonHelpers.Tests.ps1`, `Tests/Scoop`,
  `Tests/Utils/ScriptSafetyConventions.Tests.ps1`, `Tests/Utils/BackupDxMessaging.Tests.ps1`,
  `Tests/Utils/CompatibilityConventions.Tests.ps1`.
- `Invoke-CompatibilityChecks.ps1` over the three changed scripts: PASS across 5.1 + pwsh7 profiles.
- Managed `pre-commit run`: all hooks Passed, including `pretty format json` against the regenerated
  artifact.
- Adversarial review loop (per GOAL.md): reviewer found 4 issues (1 MAJOR); all fixed; adversarial
  verifier confirmed all RESOLVED, verdict "exceptional, zero issues".

## Follow-ups

- Tomorrow's backup commit names the two persistently failing steps; investigation continues under
  issue #46 with that concrete evidence.
- Issues #68/#70 remaining items stay operator-side (`window-control.ahk` redeploy on the primary host).

Closes #46 investigation groundwork; does not close #46 until the named-steps evidence lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup commit messaging and the shared JSON canonicalizer used for committed config artifacts. Sorting is opt-in and fail-closed, but a bug here could rewrite snapshot JSON or hide backup-step names.
> 
> **Overview**
> Addresses issue #46 from repo evidence: partial auto-backups were undiagnosable from git history, and `scoop export` hashtable order rewrote all of `Config/scoopfile.json` every day with no data change.
> 
> **Backup commits now name failing steps** in the persistent message (`backup steps failed: N [StepA, StepB]; X/Y succeeded`), policy-pinned in the conventions suite. Console-only summaries stay as they were.
> 
> **Canonical JSON gains opt-in `-SortObjectKeys`**: recursive Ordinal member sort via `ConvertTo-JsonNodeWithSortedObjectKeys` (arrays untouched, leaves round-tripped so timestamps/numbers stay verbatim). Duplicate keys fail closed (`E_CANONICAL_JSON_SORT_FAILED`); missing `System.Text.Json.Nodes` warns instead of silently skipping. `ScoopBackup` opts in; committed `scoopfile.json` is regenerated as a fixed point of both sorted and unsorted canonicalization (hook still `--no-sort-keys`).
> 
> Default canonicalizer order is unchanged for other writers. Follow-up: next host backup should name the two persistent failures so #46 RCA can continue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528a9e35232463d987745eccba57dbf4c3e3a30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->